### PR TITLE
fix: transform workspace:* deps to real versions before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
     "packages/*",
     "apps/*"
   ],
+  "scripts": {
+    "transform-deps": "bun scripts/transform-workspace-deps.ts",
+    "restore-deps": "bun scripts/restore-workspace-deps.ts",
+    "check-deps": "bun scripts/check-published-deps.ts"
+  },
   "dependencies": {
     "biome": "^0.3.3"
   }

--- a/packages/artifacts/package.json
+++ b/packages/artifacts/package.json
@@ -22,7 +22,7 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "clean": "rm -rf dist",
-    "prepublishOnly": "bun run clean && bun run build",
+    "prepublishOnly": "bun ../../scripts/transform-workspace-deps.ts && bun run clean && bun run build",
     "type-check": "tsc --noEmit"
   },
   "keywords": [

--- a/scripts/check-published-deps.ts
+++ b/scripts/check-published-deps.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env bun
+
+import { readFileSync, readdirSync, existsSync } from "fs";
+import { join } from "path";
+
+// Check for workspace:* dependencies in publishable packages
+function checkPublishedPackages(): void {
+  const packagesDir = join(import.meta.dir, "../packages");
+  let hasWorkspaceDeps = false;
+
+  try {
+    readdirSync(packagesDir).forEach((dir) => {
+      const pkgPath = join(packagesDir, dir, "package.json");
+      if (existsSync(pkgPath)) {
+        const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+
+        // Skip private packages
+        if (pkg.private === true) {
+          return;
+        }
+
+        // Check if package has publishConfig (indicating it should be published)
+        const isPublishable = pkg.publishConfig || pkg.private === false;
+
+        if (isPublishable) {
+          (
+            ["dependencies", "devDependencies", "peerDependencies"] as const
+          ).forEach((depType) => {
+            if (pkg[depType]) {
+              Object.entries(pkg[depType]).forEach(([depName, version]) => {
+                if (version === "workspace:*") {
+                  console.error(
+                    `❌ Found workspace:* dependency in publishable package`,
+                  );
+                  console.error(`   Package: ${pkg.name}`);
+                  console.error(`   Dependency: ${depName}: ${version}`);
+                  console.error(`   This will break external installation!`);
+                  hasWorkspaceDeps = true;
+                }
+              });
+            }
+          });
+        }
+      }
+    });
+
+    if (!hasWorkspaceDeps) {
+      console.log(
+        "✅ No workspace:* dependencies found in publishable packages",
+      );
+    }
+  } catch (error) {
+    console.error("Error checking packages:", error);
+    process.exit(1);
+  }
+
+  if (hasWorkspaceDeps) {
+    process.exit(1);
+  }
+}
+
+// Main execution
+if (import.meta.main) {
+  console.log(
+    "🔍 Checking for workspace:* dependencies in publishable packages...",
+  );
+  checkPublishedPackages();
+}

--- a/scripts/restore-workspace-deps.ts
+++ b/scripts/restore-workspace-deps.ts
@@ -1,0 +1,79 @@
+#!/usr/bin/env bun
+
+import { readFileSync, writeFileSync, readdirSync, existsSync } from "fs";
+import { join } from "path";
+
+// Read workspace packages to get package names
+function getWorkspacePackageNames(): Set<string> {
+  const packages = new Set<string>();
+  const packagesDir = join(import.meta.dir, "../packages");
+
+  try {
+    readdirSync(packagesDir).forEach((dir) => {
+      const pkgPath = join(packagesDir, dir, "package.json");
+      if (existsSync(pkgPath)) {
+        const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+        if (pkg.name) {
+          packages.add(pkg.name);
+        }
+      }
+    });
+  } catch (error) {
+    console.error("Error reading workspace packages:", error);
+    process.exit(1);
+  }
+
+  return packages;
+}
+
+// Restore workspace:* deps in current package.json
+function restoreDeps(): void {
+  const pkgPath = join(process.cwd(), "package.json");
+
+  if (!existsSync(pkgPath)) {
+    console.error("No package.json found in current directory");
+    process.exit(1);
+  }
+
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+    const workspacePackages = getWorkspacePackageNames();
+
+    let changed = false;
+
+    (["dependencies", "devDependencies", "peerDependencies"] as const).forEach(
+      (depType) => {
+        if (pkg[depType]) {
+          Object.keys(pkg[depType]).forEach((depName) => {
+            if (
+              workspacePackages.has(depName) &&
+              pkg[depType][depName] !== "workspace:*"
+            ) {
+              const oldVersion = pkg[depType][depName];
+              pkg[depType][depName] = "workspace:*";
+              changed = true;
+              console.log(`✓ Restored ${depName}: ${oldVersion} → workspace:*`);
+            }
+          });
+        }
+      },
+    );
+
+    if (changed) {
+      writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+      console.log(`✓ Updated ${pkgPath}`);
+    } else {
+      console.log("ℹ No workspace dependencies found to restore");
+    }
+  } catch (error) {
+    console.error("Error restoring dependencies:", error);
+    process.exit(1);
+  }
+}
+
+// Main execution
+if (import.meta.main) {
+  console.log("🔄 Restoring workspace dependencies...");
+  restoreDeps();
+  console.log("✅ Workspace dependency restoration complete");
+}

--- a/scripts/transform-workspace-deps.ts
+++ b/scripts/transform-workspace-deps.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env bun
+
+import { readFileSync, writeFileSync, readdirSync, existsSync } from "fs";
+import { join } from "path";
+
+// Read workspace packages to get current versions
+function getWorkspaceVersions(): Record<string, string> {
+  const packages: Record<string, string> = {};
+  const packagesDir = join(import.meta.dir, "../packages");
+
+  try {
+    readdirSync(packagesDir).forEach((dir) => {
+      const pkgPath = join(packagesDir, dir, "package.json");
+      if (existsSync(pkgPath)) {
+        const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+        if (pkg.name && pkg.version) {
+          packages[pkg.name] = pkg.version;
+        }
+      }
+    });
+  } catch (error) {
+    console.error("Error reading workspace packages:", error);
+    process.exit(1);
+  }
+
+  return packages;
+}
+
+// Transform workspace:* deps in current package.json
+function transformDeps(): void {
+  const pkgPath = join(process.cwd(), "package.json");
+
+  if (!existsSync(pkgPath)) {
+    console.error("No package.json found in current directory");
+    process.exit(1);
+  }
+
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+    const versions = getWorkspaceVersions();
+
+    let changed = false;
+
+    (["dependencies", "devDependencies", "peerDependencies"] as const).forEach(
+      (depType) => {
+        if (pkg[depType]) {
+          Object.keys(pkg[depType]).forEach((depName) => {
+            if (pkg[depType][depName] === "workspace:*" && versions[depName]) {
+              const newVersion = `^${versions[depName]}`;
+              pkg[depType][depName] = newVersion;
+              changed = true;
+              console.log(
+                `✓ Transformed ${depName}: workspace:* → ${newVersion}`,
+              );
+            }
+          });
+        }
+      },
+    );
+
+    if (changed) {
+      writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+      console.log(`✓ Updated ${pkgPath}`);
+    } else {
+      console.log("ℹ No workspace dependencies found to transform");
+    }
+  } catch (error) {
+    console.error("Error transforming dependencies:", error);
+    process.exit(1);
+  }
+}
+
+// Main execution
+if (import.meta.main) {
+  console.log("🔄 Transforming workspace dependencies...");
+  transformDeps();
+  console.log("✅ Workspace dependency transformation complete");
+}


### PR DESCRIPTION
- Add `transform-workspace-deps.ts` script to convert workspace:* → ^version
- Add `restore-workspace-deps.ts` script to revert back to workspace:*
- Add `check-published-deps.ts` script to verify no workspace:* in publishable packages
- Update artifacts package `prepublishOnly` script to transform dependencies
- Add utility scripts to root package.json

Fixes #14 (your publishing pipeline is not public, but at least I hope this will fix it)