### PR TITLE
feat: refactor chat store creation and add to exports + remove _lastMessageCount state

### DIFF
--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -22,5 +22,6 @@ export {
   useVirtualMessages,
   useMessageCount,
   useSelector,
+  createChatStoreCreator,
   type StoreState,
 } from "./hooks";


### PR DESCRIPTION
- Introduced `createChatStoreCreator` for better store initialization.
- Removed `_lastMessageCount` from state and optimized message updates. (can be obtained from messages on O(1) time)
