### PR TITLE
refactor(website): replace package install code blocks with InstallSc…

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,11 +5,13 @@ This monorepo uses [Changesets](https://github.com/changesets/changesets) for au
 ## How It Works
 
 ### For Development
+
 - Use `workspace:*` dependencies in `devDependencies` for local development
 - Use proper version ranges in `dependencies` for published packages
 - Changesets automatically handles version synchronization
 
 ### For Publishing
+
 1. **Create a changeset**: `bun run changeset`
 2. **Version packages**: `bun run version-packages` (or automated via CI)
 3. **Publish**: `bun run release` (or automated via CI)
@@ -17,12 +19,14 @@ This monorepo uses [Changesets](https://github.com/changesets/changesets) for au
 ## Package Dependencies
 
 ### Current Structure
+
 - `@ai-sdk-tools/store` (v0.1.0) - Base store package
 - `@ai-sdk-tools/artifacts` (v0.2.1) - Depends on store
 - `@ai-sdk-tools/devtools` (v0.6.0) - Independent package
 - `@ai-sdk-tools/chrome-extension` (v1.0.0) - Depends on store and devtools
 
 ### Publishing Order
+
 1. `@ai-sdk-tools/store` (no internal dependencies)
 2. `@ai-sdk-tools/devtools` (no internal dependencies)
 3. `@ai-sdk-tools/artifacts` (depends on store)
@@ -54,18 +58,22 @@ bun run release:beta        # Publish beta packages to npm
 ## CI/CD
 
 ### Stable Releases
+
 The main GitHub Actions workflow automatically:
+
 1. Builds all packages
 2. Creates release PRs when changesets are added
 3. Publishes packages when PR is merged
 
 ### Beta Releases
+
 Two ways to trigger beta releases:
 
 1. **Push to beta branch**: Automatically triggers beta release workflow
 2. **Manual workflow dispatch**: Go to Actions → Release → Run workflow → Select "beta"
 
 Beta releases will:
+
 - Use `beta` tag on npm (e.g., `1.0.0-beta.1`)
 - Create beta-specific changelogs
 - Allow testing before stable release
@@ -76,16 +84,19 @@ Beta releases will:
 ### Creating a Beta Release
 
 1. **Enter beta mode**:
+
    ```bash
    bun run changeset:beta
    ```
 
 2. **Create changesets** (same as stable):
+
    ```bash
    bun run changeset
    ```
 
 3. **Version and publish beta**:
+
    ```bash
    bun run version-packages:beta
    bun run release:beta
@@ -98,12 +109,80 @@ Beta releases will:
 
 ### Installing Beta Packages
 
-Users can install beta versions using:
+Users can install beta versions using various package managers:
+
+**npm:**
+
 ```bash
 npm install @ai-sdk-tools/store@beta
 npm install @ai-sdk-tools/artifacts@beta
 npm install @ai-sdk-tools/devtools@beta
-# Note: Chrome extension is not available in beta releases
+```
+
+**yarn:**
+
+```bash
+yarn add @ai-sdk-tools/store@beta
+yarn add @ai-sdk-tools/artifacts@beta
+yarn add @ai-sdk-tools/devtools@beta
+```
+
+**pnpm:**
+
+```bash
+pnpm add @ai-sdk-tools/store@beta
+pnpm add @ai-sdk-tools/artifacts@beta
+pnpm add @ai-sdk-tools/devtools@beta
+```
+
+**bun:**
+
+```bash
+bun add @ai-sdk-tools/store@beta
+bun add @ai-sdk-tools/artifacts@beta
+bun add @ai-sdk-tools/devtools@beta
+```
+
+> Note: Chrome extension is not available in beta releases
+
+### Installing Stable Packages
+
+Users can install stable versions using various package managers:
+
+**npm:**
+
+```bash
+npm install @ai-sdk-tools/store
+npm install @ai-sdk-tools/artifacts
+npm install @ai-sdk-tools/devtools
+npm install @ai-sdk-tools/chrome-extension
+```
+
+**yarn:**
+
+```bash
+yarn add @ai-sdk-tools/store
+yarn add @ai-sdk-tools/artifacts
+yarn add @ai-sdk-tools/devtools
+yarn add @ai-sdk-tools/chrome-extension
+```
+
+**pnpm:**
+
+```bash
+pnpm add @ai-sdk-tools/store
+pnpm add @ai-sdk-tools/artifacts
+pnpm add @ai-sdk-tools/devtools
+pnpm add @ai-sdk-tools/chrome-extension
+```
+
+**bun:**
+
+```bash
+bun add @ai-sdk-tools/store
+bun add @ai-sdk-tools/artifacts
+bun add @ai-sdk-tools/devtools
+bun add @ai-sdk-tools/chrome-extension
 ```
 
 ## Best Practices
@@ -119,15 +198,18 @@ npm install @ai-sdk-tools/devtools@beta
 ## Troubleshooting
 
 ### Workspace Dependencies
+
 - Never use `workspace:*` in `dependencies` for published packages
 - Use `workspace:*` only in `devDependencies` for local development
 - Use proper version ranges (`^1.0.0`) for published dependencies
 
 ### Version Conflicts
+
 - Changesets automatically handles version synchronization
 - If manual intervention needed, update package.json versions and run `bun run version-packages`
 
 ### Publishing Issues
+
 - Ensure all packages build successfully before publishing
 - Check that NPM_TOKEN is set in GitHub secrets
 - Verify package access permissions

--- a/apps/website/src/app/page.tsx
+++ b/apps/website/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { CopyButton } from "@/components/copy-button";
 import { DevtoolsDemo } from "@/components/devtools-demo";
 import { LiveDemo } from "@/components/live-demo";
+import { InstallScriptTabs } from "@/components/install-script-tabs";
 
 export default function Home() {
   const [focusedDemo, setFocusedDemo] = useState<"store" | "devtools">("store");
@@ -35,16 +36,11 @@ export default function Home() {
 
             {/* Package Installation */}
             <div className="flex flex-col gap-3 max-w-sm">
-              <div className="flex items-center justify-between border border-dashed border-[#2a2a2a] px-3 py-2 bg-[#0a0a0a]">
-                <span className="text-[#d4d4d4] text-sm font-mono">
-                  npm i ai-sdk-tools
-                </span>
-                <CopyButton text="npm i ai-sdk-tools" />
-              </div>
               <p className="text-[10px] text-secondary/60 font-light leading-relaxed">
                 Complete toolkit with all features. Individual packages also
                 available.
               </p>
+              <InstallScriptTabs />
             </div>
 
             {/* Used by */}

--- a/apps/website/src/components/agents-content.tsx
+++ b/apps/website/src/components/agents-content.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { highlight } from "sugar-high";
 import { CopyButton } from "./copy-button";
+import { InstallScriptTabs } from "./install-script-tabs";
 
 export default function AgentsContent() {
   return (
@@ -22,12 +23,7 @@ export default function AgentsContent() {
             </p>
 
             {/* Terminal */}
-            <div className="flex items-center justify-between border border-dashed border-[#2a2a2a] px-3 py-1.5 max-w-md">
-              <span className="text-[#d4d4d4] text-xs font-mono">
-                npm i @ai-sdk-tools/agents ai zod
-              </span>
-              <CopyButton text="npm i @ai-sdk-tools/agents ai zod" />
-            </div>
+            <InstallScriptTabs packageName="@ai-sdk-tools/agents ai zod" />
 
             {/* Used by */}
             <div className="space-y-6 max-w-xl">

--- a/apps/website/src/components/artifacts-content.tsx
+++ b/apps/website/src/components/artifacts-content.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import { highlight } from "sugar-high";
 import { CopyButton } from "./copy-button";
+import { InstallScriptTabs } from "./install-script-tabs";
 
 export function ArtifactsContent() {
   const [currentDemo, setCurrentDemo] = useState(0);
@@ -49,12 +50,8 @@ export function ArtifactsContent() {
             </p>
 
             {/* Terminal */}
-            <div className="flex items-center justify-between border border-dashed border-[#2a2a2a] px-3 py-1.5 max-w-md">
-              <span className="text-[#d4d4d4] text-xs font-mono">
-                npm i @ai-sdk-tools/artifacts @ai-sdk-tools/store
-              </span>
-              <CopyButton text="npm i @ai-sdk-tools/artifacts @ai-sdk-tools/store" />
-            </div>
+
+            <InstallScriptTabs packageName="@ai-sdk-tools/artifacts @ai-sdk-tools/store" />
 
             {/* Used by */}
             <div className="space-y-6 max-w-xl">
@@ -427,15 +424,12 @@ function DashboardComponent() {
         {/* Bottom CTA */}
         <div className="text-center space-y-6">
           <div className="border border-dashed border-muted-foreground p-6 max-w-xl mx-auto">
-            <div className="flex items-center justify-between">
-              <span className="text-sm font-mono">
-                npm i @ai-sdk-tools/artifacts @ai-sdk-tools/store
-              </span>
-              <CopyButton
-                text="npm i @ai-sdk-tools/artifacts @ai-sdk-tools/store"
-                size={16}
-              />
-            </div>
+            <h1 className="text-left text-xl mb-1">Get started</h1>
+            <p className="text-sm mb-4 text-secondary font-light leading-relaxed text-left">
+              Artifacts requires the store package to work properly, so make
+              sure to install both.
+            </p>
+            <InstallScriptTabs packageName="@ai-sdk-tools/artifacts @ai-sdk-tools/store" />
           </div>
           <p className="text-xs text-[#555555] font-light">
             Comprehensive artifact handling for AI applications.

--- a/apps/website/src/components/cache-content.tsx
+++ b/apps/website/src/components/cache-content.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { highlight } from "sugar-high";
+import { InstallScriptTabs } from "./install-script-tabs";
 
 export function CacheContent() {
   return (
@@ -21,30 +22,7 @@ export function CacheContent() {
             </p>
 
             {/* Terminal */}
-            <div className="flex items-center justify-between border border-dashed border-[#2a2a2a] px-3 py-1.5 max-w-md">
-              <span className="text-[#d4d4d4] text-xs font-mono">
-                npm i @ai-sdk-tools/cache
-              </span>
-              <button
-                type="button"
-                onClick={() =>
-                  navigator.clipboard.writeText("npm i @ai-sdk-tools/cache")
-                }
-                className="text-secondary hover:text-[#d4d4d4] transition-colors p-1"
-                title={`Copy "npm i @ai-sdk-tools/cache" to clipboard`}
-              >
-                <svg
-                  width="14"
-                  height="14"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                  aria-label="Copy command"
-                >
-                  <title>Copy to clipboard</title>
-                  <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
-                </svg>
-              </button>
-            </div>
+            <InstallScriptTabs packageName="@ai-sdk-tools/cache" />
 
             {/* Used by */}
             <div className="space-y-6 max-w-xl">

--- a/apps/website/src/components/devtools-content.tsx
+++ b/apps/website/src/components/devtools-content.tsx
@@ -3,6 +3,7 @@
 import { highlight } from "sugar-high";
 import { CopyButton } from "./copy-button";
 import { DevtoolsDemo } from "./devtools-demo";
+import { InstallScriptTabs } from "./install-script-tabs";
 
 export function DevtoolsContent() {
   return (
@@ -23,12 +24,7 @@ export function DevtoolsContent() {
             </p>
 
             {/* Terminal */}
-            <div className="flex items-center justify-between border border-dashed border-[#2a2a2a] px-3 py-1.5 max-w-md">
-              <span className="text-[#d4d4d4] text-xs font-mono">
-                npm i @ai-sdk-tools/devtools
-              </span>
-              <CopyButton text="npm i @ai-sdk-tools/devtools" />
-            </div>
+            <InstallScriptTabs packageName="@ai-sdk-tools/devtools" />
 
             {/* Used by */}
             <div className="space-y-6 max-w-xl">

--- a/apps/website/src/components/docs/agents-docs-content.tsx
+++ b/apps/website/src/components/docs/agents-docs-content.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { highlight } from "sugar-high";
 import { CopyButton } from "../copy-button";
+import { InstallScriptTabs } from "../install-script-tabs";
 
 export default function AgentsDocsContent() {
   return (
@@ -20,12 +21,7 @@ export default function AgentsDocsContent() {
               seamless coordination. Works with any AI provider.
             </p>
 
-            <div className="flex items-center justify-between border border-dashed border-[#2a2a2a] px-3 py-1.5 max-w-md mb-8">
-              <span className="text-[#d4d4d4] text-xs font-mono">
-                npm i @ai-sdk-tools/agents ai zod
-              </span>
-              <CopyButton text="npm i @ai-sdk-tools/agents ai zod" />
-            </div>
+            <InstallScriptTabs packageName="@ai-sdk-tools/agents ai zod" />
           </div>
         </section>
 

--- a/apps/website/src/components/docs/artifacts-content.tsx
+++ b/apps/website/src/components/docs/artifacts-content.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { highlight } from "sugar-high";
+import { InstallScriptTabs } from "../install-script-tabs";
 
 export default function ArtifactsContent() {
   return (
@@ -19,31 +20,7 @@ export default function ArtifactsContent() {
               AI tools to React components with progress tracking and error
               handling.
             </p>
-
-            <div className="flex items-center justify-between border border-dashed border-[#2a2a2a] px-3 py-1.5 max-w-md mb-8">
-              <span className="text-[#d4d4d4] text-xs font-mono">
-                npm i @ai-sdk-tools/artifacts
-              </span>
-              <button
-                type="button"
-                onClick={() =>
-                  navigator.clipboard.writeText("npm i @ai-sdk-tools/artifacts")
-                }
-                className="text-secondary hover:text-[#d4d4d4] transition-colors p-1"
-                title={`Copy "npm i @ai-sdk-tools/artifacts" to clipboard`}
-              >
-                <svg
-                  width="14"
-                  height="14"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                  aria-label="Copy command"
-                >
-                  <title>Copy command to clipboard</title>
-                  <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
-                </svg>
-              </button>
-            </div>
+            <InstallScriptTabs packageName="@ai-sdk-tools/artifacts" />
           </div>
         </section>
 
@@ -111,14 +88,7 @@ export default function ArtifactsContent() {
               <h3 className="text-lg font-medium mb-4">
                 1. Install the package
               </h3>
-              <div className="bg-transparent p-4 rounded border border-[#2a2a2a]">
-                <pre
-                  className="text-xs font-mono leading-relaxed"
-                  dangerouslySetInnerHTML={{
-                    __html: highlight(`npm install @ai-sdk-tools/artifacts`),
-                  }}
-                />
-              </div>
+              <InstallScriptTabs packageName="@ai-sdk-tools/artifacts" />
             </div>
 
             <div>

--- a/apps/website/src/components/docs/cache-content.tsx
+++ b/apps/website/src/components/docs/cache-content.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { highlight } from "sugar-high";
 import { CopyButton } from "../copy-button";
+import { InstallScriptTabs } from "../install-script-tabs";
 
 export default function CacheContent() {
   return (
@@ -15,16 +16,12 @@ export default function CacheContent() {
               Cache
             </h1>
             <p className="text-base text-secondary max-w-3xl leading-relaxed font-light mb-12">
-              Universal caching wrapper for AI SDK tools. Cache expensive tool executions 
-              with zero configuration - works with regular tools, streaming tools, and artifacts.
+              Universal caching wrapper for AI SDK tools. Cache expensive tool
+              executions with zero configuration - works with regular tools,
+              streaming tools, and artifacts.
             </p>
 
-            <div className="flex items-center justify-between border border-dashed border-[#2a2a2a] px-3 py-1.5 max-w-md mb-8">
-              <span className="text-[#d4d4d4] text-xs font-mono">
-                npm i @ai-sdk-tools/cache
-              </span>
-              <CopyButton text="npm i @ai-sdk-tools/cache" />
-            </div>
+            <InstallScriptTabs packageName="@ai-sdk-tools/cache" />
           </div>
         </section>
 
@@ -37,7 +34,8 @@ export default function CacheContent() {
                 <pre
                   className="text-sm font-mono leading-relaxed"
                   dangerouslySetInnerHTML={{
-                    __html: highlight(`import { cached } from '@ai-sdk-tools/cache'
+                    __html:
+                      highlight(`import { cached } from '@ai-sdk-tools/cache'
 
 const expensiveWeatherTool = tool({
   description: 'Get weather data',
@@ -66,11 +64,14 @@ const weatherTool = cached(expensiveWeatherTool)
         {/* Universal Tool Support */}
         <section className="mb-40">
           <div className="max-w-4xl">
-            <h2 className="text-2xl font-normal mb-8">Universal Tool Support</h2>
+            <h2 className="text-2xl font-normal mb-8">
+              Universal Tool Support
+            </h2>
             <div className="space-y-12">
-              
               <div>
-                <h3 className="text-xl font-normal mb-4">Regular Tools (async function)</h3>
+                <h3 className="text-xl font-normal mb-4">
+                  Regular Tools (async function)
+                </h3>
                 <div className="border border-[#2a2a2a] p-6">
                   <pre
                     className="text-sm font-mono leading-relaxed"
@@ -87,7 +88,9 @@ const weatherTool = cached(expensiveWeatherTool)
               </div>
 
               <div>
-                <h3 className="text-xl font-normal mb-4">Streaming Tools (async function*)</h3>
+                <h3 className="text-xl font-normal mb-4">
+                  Streaming Tools (async function*)
+                </h3>
                 <div className="border border-[#2a2a2a] p-6">
                   <pre
                     className="text-sm font-mono leading-relaxed"
@@ -105,7 +108,9 @@ const weatherTool = cached(expensiveWeatherTool)
               </div>
 
               <div>
-                <h3 className="text-xl font-normal mb-4">Artifact Tools (with writer data)</h3>
+                <h3 className="text-xl font-normal mb-4">
+                  Artifact Tools (with writer data)
+                </h3>
                 <div className="border border-[#2a2a2a] p-6">
                   <pre
                     className="text-sm font-mono leading-relaxed"
@@ -131,14 +136,16 @@ const weatherTool = cached(expensiveWeatherTool)
           <div className="max-w-4xl">
             <h2 className="text-2xl font-normal mb-8">Cache Backends</h2>
             <div className="space-y-12">
-              
               <div>
-                <h3 className="text-xl font-normal mb-4">LRU Cache (Default)</h3>
+                <h3 className="text-xl font-normal mb-4">
+                  LRU Cache (Default)
+                </h3>
                 <div className="border border-[#2a2a2a] p-6">
                   <pre
                     className="text-sm font-mono leading-relaxed"
                     dangerouslySetInnerHTML={{
-                      __html: highlight(`import { cached } from '@ai-sdk-tools/cache'
+                      __html:
+                        highlight(`import { cached } from '@ai-sdk-tools/cache'
 
 // Uses LRU cache automatically
 const weatherTool = cached(expensiveWeatherTool, {
@@ -152,12 +159,15 @@ const weatherTool = cached(expensiveWeatherTool, {
               </div>
 
               <div>
-                <h3 className="text-xl font-normal mb-4">Redis Cache (Production)</h3>
+                <h3 className="text-xl font-normal mb-4">
+                  Redis Cache (Production)
+                </h3>
                 <div className="border border-[#2a2a2a] p-6">
                   <pre
                     className="text-sm font-mono leading-relaxed"
                     dangerouslySetInnerHTML={{
-                      __html: highlight(`import { createCachedFunction, createCacheBackend } from '@ai-sdk-tools/cache'
+                      __html:
+                        highlight(`import { createCachedFunction, createCacheBackend } from '@ai-sdk-tools/cache'
 import Redis from 'redis'
 
 const redis = Redis.createClient({
@@ -181,7 +191,9 @@ export const cached = createCachedFunction(redisBackend)`),
               </div>
 
               <div>
-                <h3 className="text-xl font-normal mb-4">Environment-Aware Setup</h3>
+                <h3 className="text-xl font-normal mb-4">
+                  Environment-Aware Setup
+                </h3>
                 <div className="border border-[#2a2a2a] p-6">
                   <pre
                     className="text-sm font-mono leading-relaxed"
@@ -212,16 +224,20 @@ export const cached = createCachedFunction(backend)
         {/* Streaming Tools Requirements */}
         <section className="mb-40">
           <div className="max-w-4xl">
-            <h2 className="text-2xl font-normal mb-8">Streaming Tools Requirements</h2>
+            <h2 className="text-2xl font-normal mb-8">
+              Streaming Tools Requirements
+            </h2>
             <p className="text-base text-secondary mb-6 leading-relaxed font-light">
-              For complete caching of streaming tools with artifacts, ensure your API route passes the writer:
+              For complete caching of streaming tools with artifacts, ensure
+              your API route passes the writer:
             </p>
-            
+
             <div className="border border-[#2a2a2a] p-6 mb-8">
               <pre
                 className="text-sm font-mono leading-relaxed"
                 dangerouslySetInnerHTML={{
-                  __html: highlight(`// API route setup (required for artifact caching)
+                  __html:
+                    highlight(`// API route setup (required for artifact caching)
 const stream = createUIMessageStream({
   execute: ({ writer }) => {
     setContext({ writer }) // Set up artifacts context
@@ -242,7 +258,11 @@ const stream = createUIMessageStream({
 
             <div className="bg-yellow-900/20 border border-yellow-600/30 rounded p-6">
               <p className="font-medium mb-4">
-                <strong>Important:</strong> Without <code className="bg-black/30 px-1 py-0.5 rounded text-xs">experimental_context: {`{ writer }`}</code>:
+                <strong>Important:</strong> Without{" "}
+                <code className="bg-black/30 px-1 py-0.5 rounded text-xs">
+                  experimental_context: {`{ writer }`}
+                </code>
+                :
               </p>
               <ul className="space-y-2 mb-4 text-sm">
                 <li className="flex items-center gap-2">
@@ -273,20 +293,32 @@ const stream = createUIMessageStream({
             <h2 className="text-2xl font-normal mb-8">Performance Benefits</h2>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               <div className="border border-[#2a2a2a] p-6">
-                <h3 className="text-lg font-medium mb-3">10x faster responses</h3>
+                <h3 className="text-lg font-medium mb-3">
+                  10x faster responses
+                </h3>
                 <p className="text-sm text-secondary">for repeated requests</p>
               </div>
               <div className="border border-[#2a2a2a] p-6">
                 <h3 className="text-lg font-medium mb-3">80% cost reduction</h3>
-                <p className="text-sm text-secondary">by avoiding duplicate calls</p>
+                <p className="text-sm text-secondary">
+                  by avoiding duplicate calls
+                </p>
               </div>
               <div className="border border-[#2a2a2a] p-6">
-                <h3 className="text-lg font-medium mb-3">Smooth agent conversations</h3>
-                <p className="text-sm text-secondary">with instant cached results</p>
+                <h3 className="text-lg font-medium mb-3">
+                  Smooth agent conversations
+                </h3>
+                <p className="text-sm text-secondary">
+                  with instant cached results
+                </p>
               </div>
               <div className="border border-[#2a2a2a] p-6">
-                <h3 className="text-lg font-medium mb-3">Complete data preservation</h3>
-                <p className="text-sm text-secondary">streaming, artifacts, everything</p>
+                <h3 className="text-lg font-medium mb-3">
+                  Complete data preservation
+                </h3>
+                <p className="text-sm text-secondary">
+                  streaming, artifacts, everything
+                </p>
               </div>
             </div>
           </div>
@@ -297,52 +329,134 @@ const stream = createUIMessageStream({
           <div className="max-w-4xl">
             <h2 className="text-2xl font-normal mb-8">API Reference</h2>
             <div className="space-y-8">
-              
               <div className="border border-[#2a2a2a] p-6">
-                <h3 className="text-xl font-normal mb-4">cached(tool, options?)</h3>
-                <p className="text-sm text-secondary mb-4">Wraps an AI SDK tool with caching capabilities.</p>
-                
+                <h3 className="text-xl font-normal mb-4">
+                  cached(tool, options?)
+                </h3>
+                <p className="text-sm text-secondary mb-4">
+                  Wraps an AI SDK tool with caching capabilities.
+                </p>
+
                 <div className="space-y-4">
                   <div>
                     <h4 className="text-base font-medium mb-2">Parameters</h4>
                     <ul className="text-sm text-secondary space-y-1">
-                      <li><code className="bg-black/30 px-1 py-0.5 rounded text-xs">tool</code> - Any AI SDK tool</li>
-                      <li><code className="bg-black/30 px-1 py-0.5 rounded text-xs">options</code> - Optional cache configuration</li>
+                      <li>
+                        <code className="bg-black/30 px-1 py-0.5 rounded text-xs">
+                          tool
+                        </code>{" "}
+                        - Any AI SDK tool
+                      </li>
+                      <li>
+                        <code className="bg-black/30 px-1 py-0.5 rounded text-xs">
+                          options
+                        </code>{" "}
+                        - Optional cache configuration
+                      </li>
                     </ul>
                   </div>
-                  
+
                   <div>
                     <h4 className="text-base font-medium mb-2">Options</h4>
                     <ul className="text-sm text-secondary space-y-1">
-                      <li><code className="bg-black/30 px-1 py-0.5 rounded text-xs">ttl</code> - Time to live in milliseconds (default: 5 minutes)</li>
-                      <li><code className="bg-black/30 px-1 py-0.5 rounded text-xs">maxSize</code> - Maximum cache size (default: 1000)</li>
-                      <li><code className="bg-black/30 px-1 py-0.5 rounded text-xs">store</code> - Custom cache backend</li>
-                      <li><code className="bg-black/30 px-1 py-0.5 rounded text-xs">keyGenerator</code> - Custom key generation function</li>
-                      <li><code className="bg-black/30 px-1 py-0.5 rounded text-xs">shouldCache</code> - Conditional caching function</li>
-                      <li><code className="bg-black/30 px-1 py-0.5 rounded text-xs">onHit</code> - Cache hit callback</li>
-                      <li><code className="bg-black/30 px-1 py-0.5 rounded text-xs">onMiss</code> - Cache miss callback</li>
-                      <li><code className="bg-black/30 px-1 py-0.5 rounded text-xs">debug</code> - Enable debug logging</li>
+                      <li>
+                        <code className="bg-black/30 px-1 py-0.5 rounded text-xs">
+                          ttl
+                        </code>{" "}
+                        - Time to live in milliseconds (default: 5 minutes)
+                      </li>
+                      <li>
+                        <code className="bg-black/30 px-1 py-0.5 rounded text-xs">
+                          maxSize
+                        </code>{" "}
+                        - Maximum cache size (default: 1000)
+                      </li>
+                      <li>
+                        <code className="bg-black/30 px-1 py-0.5 rounded text-xs">
+                          store
+                        </code>{" "}
+                        - Custom cache backend
+                      </li>
+                      <li>
+                        <code className="bg-black/30 px-1 py-0.5 rounded text-xs">
+                          keyGenerator
+                        </code>{" "}
+                        - Custom key generation function
+                      </li>
+                      <li>
+                        <code className="bg-black/30 px-1 py-0.5 rounded text-xs">
+                          shouldCache
+                        </code>{" "}
+                        - Conditional caching function
+                      </li>
+                      <li>
+                        <code className="bg-black/30 px-1 py-0.5 rounded text-xs">
+                          onHit
+                        </code>{" "}
+                        - Cache hit callback
+                      </li>
+                      <li>
+                        <code className="bg-black/30 px-1 py-0.5 rounded text-xs">
+                          onMiss
+                        </code>{" "}
+                        - Cache miss callback
+                      </li>
+                      <li>
+                        <code className="bg-black/30 px-1 py-0.5 rounded text-xs">
+                          debug
+                        </code>{" "}
+                        - Enable debug logging
+                      </li>
                     </ul>
                   </div>
                 </div>
               </div>
 
               <div className="border border-[#2a2a2a] p-6">
-                <h3 className="text-xl font-normal mb-4">createCachedFunction(store)</h3>
-                <p className="text-sm text-secondary mb-4">Creates a pre-configured cached function with a specific store.</p>
+                <h3 className="text-xl font-normal mb-4">
+                  createCachedFunction(store)
+                </h3>
+                <p className="text-sm text-secondary mb-4">
+                  Creates a pre-configured cached function with a specific
+                  store.
+                </p>
               </div>
 
               <div className="border border-[#2a2a2a] p-6">
-                <h3 className="text-xl font-normal mb-4">createCacheBackend(config)</h3>
-                <p className="text-sm text-secondary mb-4">Creates a cache backend with the specified configuration.</p>
-                
+                <h3 className="text-xl font-normal mb-4">
+                  createCacheBackend(config)
+                </h3>
+                <p className="text-sm text-secondary mb-4">
+                  Creates a cache backend with the specified configuration.
+                </p>
+
                 <div>
                   <h4 className="text-base font-medium mb-2">Backend Types</h4>
                   <ul className="text-sm text-secondary space-y-1">
-                    <li><code className="bg-black/30 px-1 py-0.5 rounded text-xs">lru</code> - LRU cache (single instance)</li>
-                    <li><code className="bg-black/30 px-1 py-0.5 rounded text-xs">redis</code> - Redis cache (distributed)</li>
-                    <li><code className="bg-black/30 px-1 py-0.5 rounded text-xs">memory</code> - Simple memory cache</li>
-                    <li><code className="bg-black/30 px-1 py-0.5 rounded text-xs">simple</code> - Basic cache implementation</li>
+                    <li>
+                      <code className="bg-black/30 px-1 py-0.5 rounded text-xs">
+                        lru
+                      </code>{" "}
+                      - LRU cache (single instance)
+                    </li>
+                    <li>
+                      <code className="bg-black/30 px-1 py-0.5 rounded text-xs">
+                        redis
+                      </code>{" "}
+                      - Redis cache (distributed)
+                    </li>
+                    <li>
+                      <code className="bg-black/30 px-1 py-0.5 rounded text-xs">
+                        memory
+                      </code>{" "}
+                      - Simple memory cache
+                    </li>
+                    <li>
+                      <code className="bg-black/30 px-1 py-0.5 rounded text-xs">
+                        simple
+                      </code>{" "}
+                      - Basic cache implementation
+                    </li>
                   </ul>
                 </div>
               </div>
@@ -356,19 +470,31 @@ const stream = createUIMessageStream({
             <h2 className="text-2xl font-normal mb-8">Best Practices</h2>
             <div className="space-y-4">
               <div className="border border-[#2a2a2a] p-4">
-                <p className="text-sm">Use LRU cache for single instance applications</p>
+                <p className="text-sm">
+                  Use LRU cache for single instance applications
+                </p>
               </div>
               <div className="border border-[#2a2a2a] p-4">
-                <p className="text-sm">Use Redis cache for distributed/production applications</p>
+                <p className="text-sm">
+                  Use Redis cache for distributed/production applications
+                </p>
               </div>
               <div className="border border-[#2a2a2a] p-4">
-                <p className="text-sm">Set appropriate TTL values based on data freshness requirements</p>
+                <p className="text-sm">
+                  Set appropriate TTL values based on data freshness
+                  requirements
+                </p>
               </div>
               <div className="border border-[#2a2a2a] p-4">
-                <p className="text-sm">Use environment-aware configuration for seamless dev/prod switching</p>
+                <p className="text-sm">
+                  Use environment-aware configuration for seamless dev/prod
+                  switching
+                </p>
               </div>
               <div className="border border-[#2a2a2a] p-4">
-                <p className="text-sm">Enable debug mode during development to monitor cache behavior</p>
+                <p className="text-sm">
+                  Enable debug mode during development to monitor cache behavior
+                </p>
               </div>
             </div>
           </div>

--- a/apps/website/src/components/docs/devtools-content.tsx
+++ b/apps/website/src/components/docs/devtools-content.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { highlight } from "sugar-high";
+import { InstallScriptTabs } from "../install-script-tabs";
 
 export default function DevtoolsContent() {
   return (
@@ -18,31 +19,7 @@ export default function DevtoolsContent() {
               Real-time insights into tool calls, performance metrics, and
               streaming events with advanced filtering and search.
             </p>
-
-            <div className="flex items-center justify-between border border-dashed border-[#2a2a2a] px-3 py-1.5 max-w-md mb-8">
-              <span className="text-[#d4d4d4] text-xs font-mono">
-                npm i @ai-sdk-tools/devtools
-              </span>
-              <button
-                type="button"
-                onClick={() =>
-                  navigator.clipboard.writeText("npm i @ai-sdk-tools/devtools")
-                }
-                className="text-secondary hover:text-[#d4d4d4] transition-colors p-1"
-                title={`Copy "npm i @ai-sdk-tools/devtools" to clipboard`}
-              >
-                <svg
-                  width="14"
-                  height="14"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                  aria-label="Copy command"
-                >
-                  <title>Copy command to clipboard</title>
-                  <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
-                </svg>
-              </button>
-            </div>
+            <InstallScriptTabs packageName="@ai-sdk-tools/devtools" />
           </div>
         </section>
 
@@ -110,14 +87,7 @@ export default function DevtoolsContent() {
               <h3 className="text-lg font-medium mb-4">
                 1. Install the package
               </h3>
-              <div className="bg-transparent p-4 rounded border border-[#2a2a2a]">
-                <pre
-                  className="text-xs font-mono leading-relaxed"
-                  dangerouslySetInnerHTML={{
-                    __html: highlight(`npm install @ai-sdk-tools/devtools`),
-                  }}
-                />
-              </div>
+              <InstallScriptTabs packageName="@ai-sdk-tools/devtools" />
             </div>
 
             <div>

--- a/apps/website/src/components/docs/installation-content.tsx
+++ b/apps/website/src/components/docs/installation-content.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { highlight } from "sugar-high";
+import { InstallScriptTabs } from "../install-script-tabs";
 
 export default function InstallationContent() {
   return (
@@ -34,31 +35,7 @@ export default function InstallationContent() {
                 Build intelligent workflows with specialized agents and
                 automatic handoffs.
               </p>
-              <div className="flex items-center justify-between border border-dashed border-[#2a2a2a] px-3 py-1.5 max-w-md mb-8">
-                <code className="text-sm">
-                  npm i @ai-sdk-tools/agents ai zod
-                </code>
-                <button
-                  onClick={() => {
-                    navigator.clipboard.writeText(
-                      "npm i @ai-sdk-tools/agents ai zod",
-                    );
-                  }}
-                  className="text-[#888] hover:text-white transition-colors"
-                  aria-label="Copy command"
-                  title='Copy "npm i @ai-sdk-tools/agents ai zod" to clipboard'
-                >
-                  <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                  >
-                    <title>Copy to clipboard</title>
-                    <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
-                  </svg>
-                </button>
-              </div>
+              <InstallScriptTabs packageName="@ai-sdk-tools/agents ai zod" />
             </div>
 
             <div>
@@ -67,27 +44,7 @@ export default function InstallationContent() {
                 Global state management for AI applications with optimized
                 performance.
               </p>
-              <div className="flex items-center justify-between border border-dashed border-[#2a2a2a] px-3 py-1.5 max-w-md mb-8">
-                <code className="text-sm">npm i @ai-sdk-tools/store</code>
-                <button
-                  onClick={() => {
-                    navigator.clipboard.writeText("npm i @ai-sdk-tools/store");
-                  }}
-                  className="text-[#888] hover:text-white transition-colors"
-                  aria-label="Copy command"
-                  title='Copy "npm i @ai-sdk-tools/store" to clipboard'
-                >
-                  <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                  >
-                    <title>Copy to clipboard</title>
-                    <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
-                  </svg>
-                </button>
-              </div>
+              <InstallScriptTabs packageName="@ai-sdk-tools/store" />
             </div>
 
             <div>
@@ -95,29 +52,7 @@ export default function InstallationContent() {
               <p className="text-sm text-secondary mb-4">
                 Powerful debugging and monitoring tool for AI applications.
               </p>
-              <div className="flex items-center justify-between border border-dashed border-[#2a2a2a] px-3 py-1.5 max-w-md mb-8">
-                <code className="text-sm">npm i @ai-sdk-tools/devtools</code>
-                <button
-                  onClick={() => {
-                    navigator.clipboard.writeText(
-                      "npm i @ai-sdk-tools/devtools",
-                    );
-                  }}
-                  className="text-[#888] hover:text-white transition-colors"
-                  aria-label="Copy command"
-                  title='Copy "npm i @ai-sdk-tools/devtools" to clipboard'
-                >
-                  <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                  >
-                    <title>Copy to clipboard</title>
-                    <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
-                  </svg>
-                </button>
-              </div>
+              <InstallScriptTabs packageName="@ai-sdk-tools/devtools" />
             </div>
 
             <div>
@@ -126,29 +61,7 @@ export default function InstallationContent() {
                 Advanced streaming interfaces with structured data and progress
                 tracking.
               </p>
-              <div className="flex items-center justify-between border border-dashed border-[#2a2a2a] px-3 py-1.5 max-w-md mb-8">
-                <code className="text-sm">npm i @ai-sdk-tools/artifacts</code>
-                <button
-                  onClick={() => {
-                    navigator.clipboard.writeText(
-                      "npm i @ai-sdk-tools/artifacts",
-                    );
-                  }}
-                  className="text-[#888] hover:text-white transition-colors"
-                  aria-label="Copy command"
-                  title='Copy "npm i @ai-sdk-tools/artifacts" to clipboard'
-                >
-                  <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                  >
-                    <title>Copy to clipboard</title>
-                    <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
-                  </svg>
-                </button>
-              </div>
+              <InstallScriptTabs packageName="@ai-sdk-tools/artifacts" />
             </div>
 
             <div>
@@ -156,27 +69,7 @@ export default function InstallationContent() {
               <p className="text-sm text-secondary mb-4">
                 Cache expensive AI tool executions with zero configuration.
               </p>
-              <div className="flex items-center justify-between border border-dashed border-[#2a2a2a] px-3 py-1.5 max-w-md mb-8">
-                <code className="text-sm">npm i @ai-sdk-tools/cache</code>
-                <button
-                  onClick={() => {
-                    navigator.clipboard.writeText("npm i @ai-sdk-tools/cache");
-                  }}
-                  className="text-[#888] hover:text-white transition-colors"
-                  aria-label="Copy command"
-                  title='Copy "npm i @ai-sdk-tools/cache" to clipboard'
-                >
-                  <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                  >
-                    <title>Copy to clipboard</title>
-                    <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
-                  </svg>
-                </button>
-              </div>
+              <InstallScriptTabs packageName="@ai-sdk-tools/cache" />
             </div>
           </div>
         </section>
@@ -191,33 +84,11 @@ export default function InstallationContent() {
               Get all packages at once for the complete AI SDK Tools experience:
             </p>
 
-            <div className="flex items-center justify-between border border-dashed border-[#2a2a2a] px-3 py-1.5 max-w-md mb-8">
-              <code className="text-sm">
-                npm i @ai-sdk-tools/agents @ai-sdk-tools/store
+            <InstallScriptTabs
+              packageName="@ai-sdk-tools/agents @ai-sdk-tools/store
                 @ai-sdk-tools/devtools @ai-sdk-tools/artifacts
-                @ai-sdk-tools/cache ai zod
-              </code>
-              <button
-                onClick={() => {
-                  navigator.clipboard.writeText(
-                    "npm i @ai-sdk-tools/agents @ai-sdk-tools/store @ai-sdk-tools/devtools @ai-sdk-tools/artifacts @ai-sdk-tools/cache ai zod",
-                  );
-                }}
-                className="text-[#888] hover:text-white transition-colors"
-                aria-label="Copy command"
-                title='Copy "npm i @ai-sdk-tools/agents @ai-sdk-tools/store @ai-sdk-tools/devtools @ai-sdk-tools/artifacts @ai-sdk-tools/cache ai zod" to clipboard'
-              >
-                <svg
-                  width="16"
-                  height="16"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                >
-                  <title>Copy to clipboard</title>
-                  <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
-                </svg>
-              </button>
-            </div>
+                @ai-sdk-tools/cache ai zod"
+            />
           </div>
         </section>
 
@@ -225,42 +96,15 @@ export default function InstallationContent() {
         <section className="mb-40">
           <h2 className="text-2xl font-medium mb-8">Package Manager Support</h2>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-            <div className="border border-[#3c3c3c] p-6">
-              <h3 className="text-lg font-medium mb-4">npm</h3>
-              <div className="bg-transparent p-4 rounded border border-[#2a2a2a]">
-                <pre
-                  className="text-xs font-mono leading-relaxed"
-                  dangerouslySetInnerHTML={{
-                    __html: highlight(`npm install @ai-sdk-tools/store`),
-                  }}
-                />
-              </div>
-            </div>
-
-            <div className="border border-[#3c3c3c] p-6">
-              <h3 className="text-lg font-medium mb-4">yarn</h3>
-              <div className="bg-transparent p-4 rounded border border-[#2a2a2a]">
-                <pre
-                  className="text-xs font-mono leading-relaxed"
-                  dangerouslySetInnerHTML={{
-                    __html: highlight(`yarn add @ai-sdk-tools/store`),
-                  }}
-                />
-              </div>
-            </div>
-
-            <div className="border border-[#3c3c3c] p-6">
-              <h3 className="text-lg font-medium mb-4">pnpm</h3>
-              <div className="bg-transparent p-4 rounded border border-[#2a2a2a]">
-                <pre
-                  className="text-xs font-mono leading-relaxed"
-                  dangerouslySetInnerHTML={{
-                    __html: highlight(`pnpm add @ai-sdk-tools/store`),
-                  }}
-                />
-              </div>
-            </div>
+          <div className="border border-[#3c3c3c] p-6">
+            <h3 className="text-lg font-medium mb-4">
+              Install Using Any Package Manager
+            </h3>
+            <p className="text-sm text-secondary mb-6">
+              Use your preferred package manager to install any package from AI
+              SDK Tools, for example:
+            </p>
+            <InstallScriptTabs packageName="@ai-sdk-tools/store" />
           </div>
         </section>
 

--- a/apps/website/src/components/docs/memory-docs-content.tsx
+++ b/apps/website/src/components/docs/memory-docs-content.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { highlight } from "sugar-high";
 import { CopyButton } from "../copy-button";
+import { InstallScriptTabs } from "../install-script-tabs";
 
 export default function MemoryDocsContent() {
   return (
@@ -20,12 +21,7 @@ export default function MemoryDocsContent() {
               and chat persistence with a simple 4-method interface.
             </p>
 
-            <div className="flex items-center justify-between border border-dashed border-[#2a2a2a] px-3 py-1.5 max-w-md mb-8">
-              <span className="text-[#d4d4d4] text-xs font-mono">
-                npm i @ai-sdk-tools/memory
-              </span>
-              <CopyButton text="npm i @ai-sdk-tools/memory" />
-            </div>
+            <InstallScriptTabs packageName="@ai-sdk-tools/memory" />
           </div>
         </section>
 

--- a/apps/website/src/components/docs/migration-content.tsx
+++ b/apps/website/src/components/docs/migration-content.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { highlight } from "sugar-high";
+import { InstallScriptTabs } from "../install-script-tabs";
 
 export default function MigrationContent() {
   return (
@@ -57,14 +58,7 @@ import { useChat } from '@ai-sdk-tools/store'`),
               <h3 className="text-lg font-medium mb-4">
                 1. Install the package
               </h3>
-              <div className="bg-transparent p-4 rounded border border-[#2a2a2a]">
-                <pre
-                  className="text-xs font-mono leading-relaxed"
-                  dangerouslySetInnerHTML={{
-                    __html: highlight(`npm install @ai-sdk-tools/store`),
-                  }}
-                />
-              </div>
+              <InstallScriptTabs packageName="@ai-sdk-tools/store" />
             </div>
 
             <div>

--- a/apps/website/src/components/docs/quickstart-content.tsx
+++ b/apps/website/src/components/docs/quickstart-content.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { highlight } from "sugar-high";
+import { InstallScriptTabs } from "../install-script-tabs";
 
 export default function QuickstartContent() {
   return (
@@ -40,91 +41,21 @@ export default function QuickstartContent() {
                     <h4 className="text-lg font-normal mb-2">
                       State Management
                     </h4>
-                    <div className="flex items-center justify-between border border-dashed border-[#2a2a2a] px-3 py-1.5 max-w-md mb-8">
-                      <code className="text-sm">npm i @ai-sdk-tools/store</code>
-                      <button
-                        onClick={() => {
-                          navigator.clipboard.writeText(
-                            "npm i @ai-sdk-tools/store",
-                          );
-                        }}
-                        className="text-[#888] hover:text-white transition-colors"
-                        aria-label="Copy command"
-                        title='Copy "npm i @ai-sdk-tools/store" to clipboard'
-                      >
-                        <svg
-                          width="16"
-                          height="16"
-                          viewBox="0 0 24 24"
-                          fill="currentColor"
-                        >
-                          <title>Copy to clipboard</title>
-                          <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
-                        </svg>
-                      </button>
-                    </div>
+                    <InstallScriptTabs packageName="@ai-sdk-tools/store" />
                   </div>
 
                   <div>
                     <h4 className="text-lg font-normal mb-2">
                       Debugging Tools
                     </h4>
-                    <div className="flex items-center justify-between border border-dashed border-[#2a2a2a] px-3 py-1.5 max-w-md mb-8">
-                      <code className="text-sm">
-                        npm i @ai-sdk-tools/devtools
-                      </code>
-                      <button
-                        onClick={() => {
-                          navigator.clipboard.writeText(
-                            "npm i @ai-sdk-tools/devtools",
-                          );
-                        }}
-                        className="text-[#888] hover:text-white transition-colors"
-                        aria-label="Copy command"
-                        title='Copy "npm i @ai-sdk-tools/devtools" to clipboard'
-                      >
-                        <svg
-                          width="16"
-                          height="16"
-                          viewBox="0 0 24 24"
-                          fill="currentColor"
-                        >
-                          <title>Copy to clipboard</title>
-                          <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
-                        </svg>
-                      </button>
-                    </div>
+                    <InstallScriptTabs packageName="@ai-sdk-tools/devtools" />
                   </div>
 
                   <div>
                     <h4 className="text-lg font-normal mb-2">
                       Streaming Interfaces
                     </h4>
-                    <div className="flex items-center justify-between border border-dashed border-[#2a2a2a] px-3 py-1.5 max-w-md mb-8">
-                      <code className="text-sm">
-                        npm i @ai-sdk-tools/artifacts
-                      </code>
-                      <button
-                        onClick={() => {
-                          navigator.clipboard.writeText(
-                            "npm i @ai-sdk-tools/artifacts",
-                          );
-                        }}
-                        className="text-[#888] hover:text-white transition-colors"
-                        aria-label="Copy command"
-                        title='Copy "npm i @ai-sdk-tools/artifacts" to clipboard'
-                      >
-                        <svg
-                          width="16"
-                          height="16"
-                          viewBox="0 0 24 24"
-                          fill="currentColor"
-                        >
-                          <title>Copy to clipboard</title>
-                          <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
-                        </svg>
-                      </button>
-                    </div>
+                    <InstallScriptTabs packageName="@ai-sdk-tools/artifacts" />
                   </div>
                 </div>
               </div>
@@ -132,32 +63,10 @@ export default function QuickstartContent() {
               {/* Complete Toolkit */}
               <div>
                 <h3 className="text-xl font-normal mb-4">Complete Toolkit</h3>
-                <div className="flex items-center justify-between border border-dashed border-[#2a2a2a] px-3 py-1.5 max-w-md mb-8">
-                  <code className="text-sm">
-                    npm i @ai-sdk-tools/store @ai-sdk-tools/devtools
-                    @ai-sdk-tools/artifacts
-                  </code>
-                  <button
-                    onClick={() => {
-                      navigator.clipboard.writeText(
-                        "npm i @ai-sdk-tools/store @ai-sdk-tools/devtools @ai-sdk-tools/artifacts",
-                      );
-                    }}
-                    className="text-[#888] hover:text-white transition-colors"
-                    aria-label="Copy command"
-                    title='Copy "npm i @ai-sdk-tools/store @ai-sdk-tools/devtools @ai-sdk-tools/artifacts" to clipboard'
-                  >
-                    <svg
-                      width="16"
-                      height="16"
-                      viewBox="0 0 24 24"
-                      fill="currentColor"
-                    >
-                      <title>Copy to clipboard</title>
-                      <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
-                    </svg>
-                  </button>
-                </div>
+                <InstallScriptTabs
+                  packageName="@ai-sdk-tools/store @ai-sdk-tools/devtools
+                    @ai-sdk-tools/artifacts"
+                />
               </div>
             </div>
           </div>

--- a/apps/website/src/components/docs/store-content.tsx
+++ b/apps/website/src/components/docs/store-content.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { highlight } from "sugar-high";
+import { InstallScriptTabs } from "../install-script-tabs";
 
 export default function StoreContent() {
   return (
@@ -14,35 +15,12 @@ export default function StoreContent() {
               Store
             </h1>
             <p className="text-base text-secondary max-w-3xl leading-relaxed font-light mb-12">
-              High-performance state management for AI applications. Drop-in replacement
-              for @ai-sdk/react with 3-5x performance improvements, O(1) message lookups,
-              and built-in optimizations.
+              High-performance state management for AI applications. Drop-in
+              replacement for @ai-sdk/react with 3-5x performance improvements,
+              O(1) message lookups, and built-in optimizations.
             </p>
 
-            <div className="flex items-center justify-between border border-dashed border-[#2a2a2a] px-3 py-1.5 max-w-md mb-8">
-              <span className="text-[#d4d4d4] text-xs font-mono">
-                npm i @ai-sdk-tools/store
-              </span>
-              <button
-                type="button"
-                onClick={() =>
-                  navigator.clipboard.writeText("npm i @ai-sdk-tools/store")
-                }
-                className="text-secondary hover:text-[#d4d4d4] transition-colors p-1"
-                title={`Copy "npm i @ai-sdk-tools/store" to clipboard`}
-              >
-                <svg
-                  width="14"
-                  height="14"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                  aria-label="Copy command"
-                >
-                  <title>Copy command to clipboard</title>
-                  <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
-                </svg>
-              </button>
-            </div>
+            <InstallScriptTabs packageName="@ai-sdk-tools/store" />
           </div>
         </section>
 
@@ -192,14 +170,7 @@ const { messages, input, handleSubmit } = useChat({
               <h3 className="text-lg font-medium mb-4">
                 1. Install the package
               </h3>
-              <div className="bg-transparent p-4 rounded border border-[#2a2a2a]">
-                <pre
-                  className="text-xs font-mono leading-relaxed"
-                  dangerouslySetInnerHTML={{
-                    __html: highlight(`npm install @ai-sdk-tools/store`),
-                  }}
-                />
-              </div>
+              <InstallScriptTabs packageName="@ai-sdk-tools/store" />
             </div>
 
             <div>

--- a/apps/website/src/components/install-script-tabs.tsx
+++ b/apps/website/src/components/install-script-tabs.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from "react";
+import { CopyButton } from "@/components/copy-button";
+
+interface InstallScriptTabsProps {
+  packageName?: string;
+}
+
+export function InstallScriptTabs({
+  packageName = "ai-sdk-tools",
+}: InstallScriptTabsProps) {
+  const [activeTab, setActiveTab] = useState<"npm" | "yarn" | "pnpm" | "bun">(
+    "npm"
+  );
+
+  const installCommands = {
+    npm: `npm install ${packageName}`,
+    yarn: `yarn add ${packageName}`,
+    pnpm: `pnpm add ${packageName}`,
+    bun: `bun add ${packageName}`,
+  };
+
+  const activeCommand = installCommands[activeTab];
+
+  return (
+    <div className="not-prose w-full max-w-lg">
+      <div className="flex">
+        {(["npm", "yarn", "pnpm", "bun"] as const).map((tab) => (
+          <button
+            key={tab}
+            className={`px-4 py-2 text-sm font-medium transition-colors ${
+              activeTab === tab
+                ? "text-[#d4d4d4] border-b-2 border-[#d4d4d4]"
+                : "text-secondary hover:text-[#d4d4d4]"
+            }`}
+            onClick={() => setActiveTab(tab)}
+          >
+            {tab}
+          </button>
+        ))}
+      </div>
+      <div className="flex items-center justify-between bg-[#0a0a0a] border border-dashed border-[#2a2a2a] p-4 rounded text-sm overflow-x-auto">
+        <pre>
+          <code>{activeCommand}</code>
+        </pre>
+        <CopyButton text={activeCommand} />
+      </div>
+    </div>
+  );
+}

--- a/apps/website/src/components/memory-content.tsx
+++ b/apps/website/src/components/memory-content.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { highlight } from "sugar-high";
 import { CopyButton } from "./copy-button";
+import { InstallScriptTabs } from "./install-script-tabs";
 
 export default function MemoryContent() {
   return (
@@ -23,12 +24,7 @@ export default function MemoryContent() {
             </p>
 
             {/* Terminal */}
-            <div className="flex items-center justify-between border border-dashed border-[#2a2a2a] px-3 py-1.5 max-w-md">
-              <span className="text-[#d4d4d4] text-xs font-mono">
-                npm i @ai-sdk-tools/memory
-              </span>
-              <CopyButton text="npm i @ai-sdk-tools/memory" />
-            </div>
+            <InstallScriptTabs packageName="@ai-sdk-tools/memory" />
 
             {/* Used by */}
             <div className="space-y-6 max-w-xl">

--- a/apps/website/src/components/store-content.tsx
+++ b/apps/website/src/components/store-content.tsx
@@ -3,6 +3,7 @@
 import { highlight } from "sugar-high";
 import { LiveDemo } from "./live-demo";
 import { CopyButton } from "./copy-button";
+import { InstallScriptTabs } from "./install-script-tabs";
 
 export function StoreContent() {
   return (
@@ -16,18 +17,13 @@ export function StoreContent() {
             </h1>
 
             <p className="text-base text-secondary max-w-3xl leading-relaxed font-light">
-              A drop-in replacement for @ai-sdk/react with 3-5x performance improvements.
-              Built-in optimizations, O(1) message lookups, batched updates, and 
-              zero configuration required.
+              A drop-in replacement for @ai-sdk/react with 3-5x performance
+              improvements. Built-in optimizations, O(1) message lookups,
+              batched updates, and zero configuration required.
             </p>
 
             {/* Terminal */}
-            <div className="flex items-center justify-between border border-dashed border-[#2a2a2a] px-3 py-1.5 max-w-md">
-              <span className="text-[#d4d4d4] text-xs font-mono">
-                npm i @ai-sdk-tools/store
-              </span>
-                <CopyButton text="npm i @ai-sdk-tools/store" />
-            </div>
+            <InstallScriptTabs packageName="@ai-sdk-tools/store" />
 
             {/* Used by */}
             <div className="space-y-6 max-w-xl">
@@ -246,8 +242,8 @@ function MessageList() {
                 <span className="text-secondary">git: (main)$ </span>
                 <span className="text-white">npm i @ai-sdk-tools/store</span>
               </div>
-              <CopyButton 
-                text="npm i @ai-sdk-tools/store" 
+              <CopyButton
+                text="npm i @ai-sdk-tools/store"
                 className="ml-4 hover:text-white"
                 size={16}
               />

--- a/packages/memory/DRIZZLE.md
+++ b/packages/memory/DRIZZLE.md
@@ -17,6 +17,10 @@ The Drizzle provider enables persistent memory storage using [Drizzle ORM](https
 npm install @ai-sdk-tools/memory drizzle-orm
 # or
 bun add @ai-sdk-tools/memory drizzle-orm
+# or
+pnpm add @ai-sdk-tools/memory drizzle-orm
+# or
+yarn add @ai-sdk-tools/memory drizzle-orm
 ```
 
 You'll also need a database driver:
@@ -94,7 +98,13 @@ const memoryProvider = new DrizzleProvider(db, {
 ```typescript
 import { connect } from "@planetscale/database";
 import { drizzle } from "drizzle-orm/planetscale-serverless";
-import { mysqlTable, int, varchar, text, timestamp } from "drizzle-orm/mysql-core";
+import {
+  mysqlTable,
+  int,
+  varchar,
+  text,
+  timestamp,
+} from "drizzle-orm/mysql-core";
 import { DrizzleProvider } from "@ai-sdk-tools/memory";
 
 const connection = connect({ url: process.env.DATABASE_URL });
@@ -218,25 +228,25 @@ Your tables must have the following columns:
 
 ### Working Memory Table
 
-| Column      | Type                | Required | Description                    |
-| ----------- | ------------------- | -------- | ------------------------------ |
-| `id`        | text/varchar        | Yes      | Primary key                    |
-| `scope`     | text/varchar        | Yes      | "chat" or "user"               |
-| `chatId`    | text/varchar        | No       | Chat identifier (nullable)     |
-| `userId`    | text/varchar        | No       | User identifier (nullable)     |
-| `content`   | text                | Yes      | Memory content                 |
-| `updatedAt` | timestamp/integer   | Yes      | Last update timestamp          |
+| Column      | Type              | Required | Description                |
+| ----------- | ----------------- | -------- | -------------------------- |
+| `id`        | text/varchar      | Yes      | Primary key                |
+| `scope`     | text/varchar      | Yes      | "chat" or "user"           |
+| `chatId`    | text/varchar      | No       | Chat identifier (nullable) |
+| `userId`    | text/varchar      | No       | User identifier (nullable) |
+| `content`   | text              | Yes      | Memory content             |
+| `updatedAt` | timestamp/integer | Yes      | Last update timestamp      |
 
 ### Messages Table
 
-| Column      | Type               | Required | Description                    |
-| ----------- | ------------------ | -------- | ------------------------------ |
-| `id`        | serial/int/integer | Yes      | Primary key (auto-increment)   |
-| `chatId`    | text/varchar       | Yes      | Chat identifier                |
-| `userId`    | text/varchar       | No       | User identifier (nullable)     |
-| `role`      | text/varchar       | Yes      | "user", "assistant", "system"  |
-| `content`   | text               | Yes      | Message content                |
-| `timestamp` | timestamp/integer  | Yes      | Message timestamp              |
+| Column      | Type               | Required | Description                   |
+| ----------- | ------------------ | -------- | ----------------------------- |
+| `id`        | serial/int/integer | Yes      | Primary key (auto-increment)  |
+| `chatId`    | text/varchar       | Yes      | Chat identifier               |
+| `userId`    | text/varchar       | No       | User identifier (nullable)    |
+| `role`      | text/varchar       | Yes      | "user", "assistant", "system" |
+| `content`   | text               | Yes      | Message content               |
+| `timestamp` | timestamp/integer  | Yes      | Message timestamp             |
 
 ## Using Existing Schema
 
@@ -309,9 +319,9 @@ CREATE TABLE IF NOT EXISTS conversation_messages (
   timestamp TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
-CREATE INDEX IF NOT EXISTS idx_working_memory_scope 
+CREATE INDEX IF NOT EXISTS idx_working_memory_scope
   ON working_memory(scope, chat_id, user_id);
-CREATE INDEX IF NOT EXISTS idx_messages_chat 
+CREATE INDEX IF NOT EXISTS idx_messages_chat
   ON conversation_messages(chat_id, timestamp DESC);
 ```
 
@@ -367,9 +377,9 @@ CREATE TABLE IF NOT EXISTS conversation_messages (
   timestamp INTEGER NOT NULL
 );
 
-CREATE INDEX IF NOT EXISTS idx_working_memory_scope 
+CREATE INDEX IF NOT EXISTS idx_working_memory_scope
   ON working_memory(scope, chat_id, user_id);
-CREATE INDEX IF NOT EXISTS idx_messages_chat 
+CREATE INDEX IF NOT EXISTS idx_messages_chat
   ON conversation_messages(chat_id, timestamp DESC);
 ```
 
@@ -460,7 +470,7 @@ class DrizzleProvider<TWM, TMsg> implements MemoryProvider {
     config: {
       workingMemoryTable: TWM;
       messagesTable: TMsg;
-    },
+    }
   );
 }
 ```
@@ -476,19 +486,20 @@ See the [main README](./README.md) for full API documentation.
 
 ## Comparison with Other Providers
 
-| Feature            | Drizzle | Upstash |
-| ------------------ | ------- | ------- |
-| Type Safety        | ✅      | ✅      |
-| PostgreSQL         | ✅      | ❌      |
-| MySQL              | ✅      | ❌      |
-| SQLite/Turso       | ✅      | ❌      |
-| Redis              | ❌      | ✅      |
-| Edge Compatible    | ✅      | ✅      |
-| ORM Integration    | ✅      | ❌      |
-| Existing Schema    | ✅      | ❌      |
-| Multi-Database     | ✅      | ❌      |
+| Feature         | Drizzle | Upstash |
+| --------------- | ------- | ------- |
+| Type Safety     | ✅      | ✅      |
+| PostgreSQL      | ✅      | ❌      |
+| MySQL           | ✅      | ❌      |
+| SQLite/Turso    | ✅      | ❌      |
+| Redis           | ❌      | ✅      |
+| Edge Compatible | ✅      | ✅      |
+| ORM Integration | ✅      | ❌      |
+| Existing Schema | ✅      | ❌      |
+| Multi-Database  | ✅      | ❌      |
 
 **Choose Drizzle if:**
+
 - You already use Drizzle in your project
 - You need PostgreSQL, MySQL, or SQLite support
 - You want to reuse existing database tables
@@ -496,6 +507,7 @@ See the [main README](./README.md) for full API documentation.
 - You use Turso for edge SQLite
 
 **Choose Upstash if:**
+
 - You want Redis for caching/sessions
 - You need ultra-low latency at edge
 - You don't need relational queries
@@ -508,4 +520,3 @@ See [examples/drizzle-example.ts](./src/examples/drizzle-example.ts) for complet
 ## License
 
 MIT
-

--- a/packages/memory/README.md
+++ b/packages/memory/README.md
@@ -15,6 +15,12 @@ Persistent memory system for AI agents with built-in providers for development a
 
 ```bash
 npm install @ai-sdk-tools/memory
+# or
+yarn add @ai-sdk-tools/memory
+# or
+pnpm add @ai-sdk-tools/memory
+# or
+bun add @ai-sdk-tools/memory
 ```
 
 ### Optional Dependencies
@@ -34,7 +40,7 @@ npm install @upstash/redis
 Perfect for local development - works immediately, no setup needed.
 
 ```typescript
-import { InMemoryProvider } from '@ai-sdk-tools/memory';
+import { InMemoryProvider } from "@ai-sdk-tools/memory";
 
 const memory = new InMemoryProvider();
 
@@ -45,7 +51,7 @@ const context = buildAppContext({
     provider: memory,
     workingMemory: {
       enabled: true,
-      scope: 'chat',
+      scope: "chat",
     },
   },
 });
@@ -56,28 +62,28 @@ const context = buildAppContext({
 Works with PostgreSQL, MySQL, and SQLite via Drizzle ORM. Perfect if you already use Drizzle in your project.
 
 ```typescript
-import { drizzle } from 'drizzle-orm/vercel-postgres';
-import { sql } from '@vercel/postgres';
-import { pgTable, serial, text, timestamp } from 'drizzle-orm/pg-core';
-import { DrizzleProvider } from '@ai-sdk-tools/memory';
+import { drizzle } from "drizzle-orm/vercel-postgres";
+import { sql } from "@vercel/postgres";
+import { pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { DrizzleProvider } from "@ai-sdk-tools/memory";
 
 // Define your schema
-const workingMemory = pgTable('working_memory', {
-  id: text('id').primaryKey(),
-  scope: text('scope').notNull(),
-  chatId: text('chat_id'),
-  userId: text('user_id'),
-  content: text('content').notNull(),
-  updatedAt: timestamp('updated_at').notNull(),
+const workingMemory = pgTable("working_memory", {
+  id: text("id").primaryKey(),
+  scope: text("scope").notNull(),
+  chatId: text("chat_id"),
+  userId: text("user_id"),
+  content: text("content").notNull(),
+  updatedAt: timestamp("updated_at").notNull(),
 });
 
-const messages = pgTable('conversation_messages', {
-  id: serial('id').primaryKey(),
-  chatId: text('chat_id').notNull(),
-  userId: text('user_id'),
-  role: text('role').notNull(),
-  content: text('content').notNull(),
-  timestamp: timestamp('timestamp').notNull(),
+const messages = pgTable("conversation_messages", {
+  id: serial("id").primaryKey(),
+  chatId: text("chat_id").notNull(),
+  userId: text("user_id"),
+  role: text("role").notNull(),
+  content: text("content").notNull(),
+  timestamp: timestamp("timestamp").notNull(),
 });
 
 // Initialize
@@ -95,8 +101,8 @@ const memory = new DrizzleProvider(db, {
 Perfect for edge and serverless environments.
 
 ```typescript
-import { Redis } from '@upstash/redis';
-import { UpstashProvider } from '@ai-sdk-tools/memory';
+import { Redis } from "@upstash/redis";
+import { UpstashProvider } from "@ai-sdk-tools/memory";
 
 const redis = Redis.fromEnv();
 const memory = new UpstashProvider(redis);
@@ -105,7 +111,7 @@ const memory = new UpstashProvider(redis);
 ## Usage with Agents
 
 ```typescript
-import { InMemoryProvider } from '@ai-sdk-tools/memory';
+import { InMemoryProvider } from "@ai-sdk-tools/memory";
 
 const appContext = buildAppContext({
   userId: "user-123",
@@ -118,7 +124,7 @@ const appContext = buildAppContext({
     provider: new InMemoryProvider(),
     workingMemory: {
       enabled: true,
-      scope: 'chat', // or 'user'
+      scope: "chat", // or 'user'
       template: `# Working Memory
 
 ## Key Facts
@@ -170,12 +176,12 @@ workingMemory: {
 Implement the `MemoryProvider` interface:
 
 ```typescript
-import type { 
-  MemoryProvider, 
-  WorkingMemory, 
+import type {
+  MemoryProvider,
+  WorkingMemory,
   ConversationMessage,
-  MemoryScope 
-} from '@ai-sdk-tools/memory';
+  MemoryScope,
+} from "@ai-sdk-tools/memory";
 
 class MyProvider implements MemoryProvider {
   async getWorkingMemory(params: {
@@ -185,7 +191,7 @@ class MyProvider implements MemoryProvider {
   }): Promise<WorkingMemory | null> {
     // Your implementation
   }
-  
+
   async updateWorkingMemory(params: {
     chatId?: string;
     userId?: string;
@@ -194,12 +200,12 @@ class MyProvider implements MemoryProvider {
   }): Promise<void> {
     // Your implementation
   }
-  
+
   // Optional methods
   async saveMessage(message: ConversationMessage): Promise<void> {
     // Your implementation
   }
-  
+
   async getMessages(params: {
     chatId: string;
     limit?: number;
@@ -225,7 +231,7 @@ interface WorkingMemory {
 #### `MemoryScope`
 
 ```typescript
-type MemoryScope = 'chat' | 'user';
+type MemoryScope = "chat" | "user";
 ```
 
 #### `ConversationMessage`
@@ -234,7 +240,7 @@ type MemoryScope = 'chat' | 'user';
 interface ConversationMessage {
   chatId: string;
   userId?: string;
-  role: 'user' | 'assistant' | 'system';
+  role: "user" | "assistant" | "system";
   content: string;
   timestamp: Date;
 }
@@ -249,16 +255,16 @@ interface MemoryProvider {
     userId?: string;
     scope: MemoryScope;
   }): Promise<WorkingMemory | null>;
-  
+
   updateWorkingMemory(params: {
     chatId?: string;
     userId?: string;
     scope: MemoryScope;
     content: string;
   }): Promise<void>;
-  
+
   saveMessage?(message: ConversationMessage): Promise<void>;
-  
+
   getMessages?(params: {
     chatId: string;
     limit?: number;
@@ -269,4 +275,3 @@ interface MemoryProvider {
 ## License
 
 MIT
-


### PR DESCRIPTION


Added InstallScriptTabs component to apps/website

- Replaced manual npm install command blocks and copy buttons with InstallScriptTabs usage
- Updated install instructions sections in various components for uniformity and better UX
- Enhanced installation documentation with multi-package manager support (npm, yarn, pnpm, bun)
- Removed redundant copy-to-clipboard buttons in favor of centralized InstallScriptTabs component
- Clarified beta vs stable installation instructions within release documentation section

<img width="747" height="385" alt="image" src="https://github.com/user-attachments/assets/70c0b770-abcc-43f1-89ad-7aa5215256ec" />