### PR TITLE
fix: implement missing `registerThrottledMessagesEffect` method

### DIFF
--- a/packages/store/src/hooks.ts
+++ b/packages/store/src/hooks.ts
@@ -548,6 +548,13 @@ export function createChatStoreCreator<TMessage extends UIMessage>(
         state._memoizedSelectors.set(key, { result, deps: [...deps] });
         return result;
       },
+
+      registerThrottledMessagesEffect: (effect: () => void) => {
+        throttledEffects.add(effect);
+        return () => {
+          throttledEffects.delete(effect);
+        };
+      },
     };
   };
 }


### PR DESCRIPTION
Hi Pontus, wanted to contribute with this fix.

Some [builds are failing](https://github.com/midday-ai/ai-sdk-tools/actions/runs/18465244120/job/52605583287) with this message: 

> error TS2322: Property 'registerThrottledMessagesEffect' is missing in type

I've implemented the `registerThrottledMessagesEffect` method in `createChatStoreCreator`

**How to reproduce**

- Clone the repo, install packages and run `bun run build`
```
   src/hooks.ts(244,3): error TS2322: Type '(set: { (partial: StoreState<TMessage> | Partial<StoreState<TMessage>> | ((state: StoreState<TMessage>) => StoreState<...> | Partial<...>), replace?: false | undefined): void; (state: StoreState<...> | ((state: StoreState<...>) => StoreState<...>), replace: true): void; }, get: () => StoreState<TMessage>) => { ...; }' is not assignable to type 'StateCreator<StoreState<TMessage>, [], []>'.
   Property 'registerThrottledMessagesEffect' is missing in type '{ id: undefined; messages: TMessage[]; status: "ready"; error: undefined; _throttledMessages: TMessage[]; _messageIndex: MessageIndex<TMessage>; ... 26 more ...; getMemoizedSelector: <T>(key: string, selector: () => T, deps: any[]) => T; }' but required in type 'StoreState<TMessage>'.
```

Environment
- **OS:** macOS 26.0.1
- **Node Version:** v20.17.0
- **Bun Version:** 1.2.22
- **Repository:** ai-sdk-tools@765ced2 (before fix)
- **TypeScript:** 5.9.3