### PR TITLE
Fix build deps error in gh actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,14 +41,6 @@ jobs:
       - name: Install Dependencies
         run: bun install --frozen-lockfile
 
-      - name: Build Packages
-        run: |
-          if [ "${{ steps.check-type.outputs.type }}" = "beta" ]; then
-            bun run build:beta
-          else
-            bun run build
-          fi
-
       - name: Check Release Type
         id: check-type
         run: |
@@ -64,6 +56,14 @@ jobs:
             echo "version_cmd=bun run version-packages" >> $GITHUB_OUTPUT
             echo "commit_msg=chore: release packages" >> $GITHUB_OUTPUT
             echo "title=chore: release packages" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build Packages
+        run: |
+          if [ "${{ steps.check-type.outputs.type }}" = "beta" ]; then
+            bun run build:beta
+          else
+            bun run build
           fi
 
       - name: Enter Beta Mode (if beta release)

--- a/packages/artifacts/package.json
+++ b/packages/artifacts/package.json
@@ -56,6 +56,7 @@
   },
   "devDependencies": {
     "@ai-sdk/react": "^2.0.60",
+    "@types/node": "^24.7.0",
     "@types/react": "^19.2.0",
     "typescript": "^5.9.3",
     "tsup": "^8.5.0",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -48,6 +48,7 @@
     }
   },
   "devDependencies": {
+    "@types/node": "^24.7.0",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.1",
     "react": "^19.2.0",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -33,6 +33,7 @@
     }
   },
   "devDependencies": {
+    "@types/node": "^24.7.0",
     "@upstash/redis": "^1.35.5",
     "drizzle-orm": "^0.44.6",
     "tsup": "^8.5.0",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -42,6 +42,7 @@
     "zustand": ">=5.0.0"
   },
   "devDependencies": {
+    "@types/node": "^24.7.0",
     "@types/react": "^19.2.0",
     "react": "^19.2.0",
     "tsup": "^8.5.0",


### PR DESCRIPTION
Add `@types/node` dependency to all `packages/*` to fix the build error.
Step `id:check-type` comes before `name:Build Packages` in release.yml