### PR TITLE
fix(example): force triage agent to complete handoff

### DIFF
--- a/apps/example/src/ai/agents/triage.ts
+++ b/apps/example/src/ai/agents/triage.ts
@@ -12,6 +12,7 @@ import { transactionsAgent } from "./transactions";
 export const triageAgent = createAgent({
   name: "triage",
   model: openai("gpt-4o-mini"),
+  modelSettings: { toolChoice: "required", activeTools: ["handoff_to_agent"] },
   instructions: (ctx) => `Route user requests to the appropriate agent:
 
 **reports**: Financial metrics and reports


### PR DESCRIPTION
If you ask it to remember something, sometimes the triage agent will call the update_memory tool on it's own when it should be handing off to another agent for that. This happens particularly with smaller models like 4.1-nano.

This fixes the issue by forcing it to call a tool, and then only giving it access to the handoff tool.