### PR TITLE
Fix @ai-sdk-tools/memory peerDeps with separate provider exports

### DIFF
--- a/apps/website/src/components/agents-content.tsx
+++ b/apps/website/src/components/agents-content.tsx
@@ -20,7 +20,10 @@ export default function AgentsContent() {
               Multi-agent orchestration for AI SDK v5. Automatic handoffs,
               programmatic routing, and seamless coordination across any AI
               provider. Perfect for complex tasks requiring distinct expertise.
-              <strong className="text-[#d4d4d4]"> Includes built-in memory system for persistent context.</strong>
+              <strong className="text-[#d4d4d4]">
+                {" "}
+                Includes built-in memory system for persistent context.
+              </strong>
             </p>
 
             {/* Terminal */}
@@ -67,7 +70,7 @@ export default function AgentsContent() {
                 dangerouslySetInnerHTML={{
                   __html:
                     highlight(`import { Agent } from '@ai-sdk-tools/agents'
-import { DrizzleProvider } from '@ai-sdk-tools/memory'
+import { DrizzleProvider } from '@ai-sdk-tools/memory/drizzle'
 import { openai } from '@ai-sdk/openai'
 
 const mathAgent = new Agent({
@@ -166,8 +169,6 @@ console.log(\`Handled by: \${result.finalAgent}\`)
               execution.
             </p>
           </div>
-
-        
         </div>
 
         {/* Use Cases */}

--- a/apps/website/src/components/docs/agents-docs-content.tsx
+++ b/apps/website/src/components/docs/agents-docs-content.tsx
@@ -18,8 +18,11 @@ export default function AgentsDocsContent() {
             <p className="text-base text-secondary max-w-3xl leading-relaxed font-light mb-12">
               Multi-agent orchestration for AI SDK v5. Build intelligent
               workflows with specialized agents, automatic handoffs, and
-              seamless coordination. Works with any AI provider. 
-              <strong className="text-[#d4d4d4]"> Includes built-in memory system for persistent context.</strong>
+              seamless coordination. Works with any AI provider.
+              <strong className="text-[#d4d4d4]">
+                {" "}
+                Includes built-in memory system for persistent context.
+              </strong>
             </p>
 
             <InstallScriptTabs packageName="@ai-sdk-tools/agents @ai-sdk-tools/memory ai zod" />
@@ -118,18 +121,19 @@ export default function AgentsDocsContent() {
               Built-in Memory System
             </h2>
             <p className="text-sm text-secondary mb-8 leading-relaxed">
-              Every agent includes a powerful memory system that maintains context across conversations. 
-              Memory is a <strong className="text-[#d4d4d4]">required dependency</strong> that provides:
+              Every agent includes a powerful memory system that maintains
+              context across conversations. Memory is a{" "}
+              <strong className="text-[#d4d4d4]">required dependency</strong>{" "}
+              that provides:
             </p>
             <div className="space-y-3 mb-8">
               <div className="flex items-start gap-3">
                 <span className="text-xs text-secondary mt-1">•</span>
                 <div>
-                  <p className="text-sm font-medium mb-1">
-                    Working Memory
-                  </p>
+                  <p className="text-sm font-medium mb-1">Working Memory</p>
                   <p className="text-xs text-secondary">
-                    Persistent context that agents can read and update during conversations
+                    Persistent context that agents can read and update during
+                    conversations
                   </p>
                 </div>
               </div>
@@ -140,16 +144,15 @@ export default function AgentsDocsContent() {
                     Conversation History
                   </p>
                   <p className="text-xs text-secondary">
-                    Automatic message persistence and retrieval across chat sessions
+                    Automatic message persistence and retrieval across chat
+                    sessions
                   </p>
                 </div>
               </div>
               <div className="flex items-start gap-3">
                 <span className="text-xs text-secondary mt-1">•</span>
                 <div>
-                  <p className="text-sm font-medium mb-1">
-                    Chat Management
-                  </p>
+                  <p className="text-sm font-medium mb-1">Chat Management</p>
                   <p className="text-xs text-secondary">
                     Automatic title generation and chat organization
                   </p>
@@ -158,11 +161,10 @@ export default function AgentsDocsContent() {
               <div className="flex items-start gap-3">
                 <span className="text-xs text-secondary mt-1">•</span>
                 <div>
-                  <p className="text-sm font-medium mb-1">
-                    Flexible Scopes
-                  </p>
+                  <p className="text-sm font-medium mb-1">Flexible Scopes</p>
                   <p className="text-xs text-secondary">
-                    Chat-level or user-level memory with multiple storage backends
+                    Chat-level or user-level memory with multiple storage
+                    backends
                   </p>
                 </div>
               </div>
@@ -173,7 +175,7 @@ export default function AgentsDocsContent() {
                 dangerouslySetInnerHTML={{
                   __html:
                     highlight(`import { Agent } from '@ai-sdk-tools/agents'
-import { InMemoryProvider } from '@ai-sdk-tools/memory'
+import { InMemoryProvider } from '@ai-sdk-tools/memory/in-memory'
 import { openai } from '@ai-sdk/openai'
 
 const agent = new Agent({
@@ -721,7 +723,7 @@ const pipeline = new Agent({
                     className="text-sm font-mono leading-relaxed"
                     dangerouslySetInnerHTML={{
                       __html:
-                        highlight(`import { DrizzleProvider } from '@ai-sdk-tools/memory'
+                        highlight(`import { DrizzleProvider } from '@ai-sdk-tools/memory/drizzle'
 
 const agent = new Agent({
   name: 'Assistant',

--- a/apps/website/src/components/docs/memory-docs-content.tsx
+++ b/apps/website/src/components/docs/memory-docs-content.tsx
@@ -18,8 +18,11 @@ export default function MemoryDocsContent() {
             <p className="text-base text-secondary max-w-3xl leading-relaxed font-light mb-12">
               Persistent memory system for AI agents with built-in providers for
               development and production. Working memory, conversation history,
-              and chat persistence with a simple 4-method interface. 
-              <strong className="text-[#d4d4d4]"> Required dependency for @ai-sdk-tools/agents.</strong>
+              and chat persistence with a simple 4-method interface.
+              <strong className="text-[#d4d4d4]">
+                {" "}
+                Required dependency for @ai-sdk-tools/agents.
+              </strong>
             </p>
 
             <InstallScriptTabs packageName="@ai-sdk-tools/memory" />
@@ -101,7 +104,7 @@ export default function MemoryDocsContent() {
                 className="text-xs font-mono leading-relaxed"
                 dangerouslySetInnerHTML={{
                   __html:
-                    highlight(`import { InMemoryProvider } from '@ai-sdk-tools/memory'
+                    highlight(`import { InMemoryProvider } from '@ai-sdk-tools/memory/in-memory'
 import { Agent } from '@ai-sdk-tools/agents'
 
 const memory = new InMemoryProvider()
@@ -154,7 +157,7 @@ const agent = new Agent({
                     highlight(`import { drizzle } from 'drizzle-orm/vercel-postgres'
 import { sql } from '@vercel/postgres'
 import { pgTable, text, timestamp } from 'drizzle-orm/pg-core'
-import { DrizzleProvider } from '@ai-sdk-tools/memory'
+import { DrizzleProvider } from '@ai-sdk-tools/memory/drizzle'
 
 // Define your schema
 const workingMemory = pgTable('working_memory', {
@@ -208,7 +211,7 @@ const memory = new DrizzleProvider(db, {
                 className="text-xs font-mono leading-relaxed"
                 dangerouslySetInnerHTML={{
                   __html: highlight(`import { Redis } from '@upstash/redis'
-import { UpstashProvider } from '@ai-sdk-tools/memory'
+import { UpstashProvider } from '@ai-sdk-tools/memory/upstash'
 
 const redis = Redis.fromEnv()
 const memory = new UpstashProvider(redis)`),
@@ -224,7 +227,9 @@ const memory = new UpstashProvider(redis)`),
           <div className="max-w-4xl">
             <h2 className="text-2xl font-normal mb-8">Usage with Agents</h2>
             <p className="text-sm text-secondary mb-6 leading-relaxed">
-              The memory package is a <strong className="text-[#d4d4d4]">required dependency</strong> for{" "}
+              The memory package is a{" "}
+              <strong className="text-[#d4d4d4]">required dependency</strong>{" "}
+              for{" "}
               <Link
                 href="/docs/agents"
                 className="text-[#d4d4d4] hover:underline"
@@ -264,7 +269,7 @@ const memory = new UpstashProvider(redis)`),
                 dangerouslySetInnerHTML={{
                   __html:
                     highlight(`import { Agent } from '@ai-sdk-tools/agents'
-import { DrizzleProvider } from '@ai-sdk-tools/memory'
+import { DrizzleProvider } from '@ai-sdk-tools/memory/drizzle'
 
 const agent = new Agent({
   name: 'Financial Assistant',
@@ -515,7 +520,7 @@ class MyCustomProvider implements MemoryProvider {
                 dangerouslySetInnerHTML={{
                   __html: highlight(`// app/api/chat/route.ts
 import { Agent } from '@ai-sdk-tools/agents'
-import { DrizzleProvider } from '@ai-sdk-tools/memory'
+import { DrizzleProvider } from '@ai-sdk-tools/memory/drizzle'
 import { openai } from '@ai-sdk/openai'
 
 const memory = new DrizzleProvider(db)

--- a/apps/website/src/components/memory-content.tsx
+++ b/apps/website/src/components/memory-content.tsx
@@ -67,7 +67,7 @@ export default function MemoryContent() {
                 dangerouslySetInnerHTML={{
                   __html:
                     highlight(`import { Agent } from '@ai-sdk-tools/agents'
-import { DrizzleProvider } from '@ai-sdk-tools/memory'
+import { DrizzleProvider } from '@ai-sdk-tools/memory/drizzle'
 
 const agent = new Agent({
   name: 'Assistant',
@@ -163,7 +163,7 @@ const agent = new Agent({
                   className="text-xs font-mono leading-relaxed"
                   dangerouslySetInnerHTML={{
                     __html:
-                      highlight(`import { InMemoryProvider } from '@ai-sdk-tools/memory'
+                      highlight(`import { InMemoryProvider } from '@ai-sdk-tools/memory/in-memory'
 
 const memory = new InMemoryProvider()
 
@@ -188,7 +188,7 @@ const memory = new InMemoryProvider()
                   className="text-xs font-mono leading-relaxed"
                   dangerouslySetInnerHTML={{
                     __html:
-                      highlight(`import { DrizzleProvider } from '@ai-sdk-tools/memory'
+                      highlight(`import { DrizzleProvider } from '@ai-sdk-tools/memory/drizzle'
 
 const memory = new DrizzleProvider(db, {
   workingMemoryTable,
@@ -215,7 +215,7 @@ const memory = new DrizzleProvider(db, {
                   className="text-xs font-mono leading-relaxed"
                   dangerouslySetInnerHTML={{
                     __html:
-                      highlight(`import { UpstashProvider } from '@ai-sdk-tools/memory'
+                      highlight(`import { UpstashProvider } from '@ai-sdk-tools/memory/upstash'
 import { Redis } from '@upstash/redis'
 
 const memory = new UpstashProvider(

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -8,6 +8,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./*": {
+      "types": "./dist/providers/*.d.ts",
+      "import": "./dist/providers/*.js",
+      "require": "./dist/providers/*.cjs"
     }
   },
   "files": [

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1,28 +1,5 @@
-// Providers
-
-export type {
-  ChatsTable,
-  ConversationMessagesTable,
-  DrizzleProviderConfig,
-  WorkingMemoryTable,
-} from "./providers/drizzle.js";
-export { DrizzleProvider } from "./providers/drizzle.js";
-// Schema Helpers
-export {
-  createMysqlChatsSchema,
-  createMysqlMessagesSchema,
-  createMysqlWorkingMemorySchema,
-  createPgChatsSchema,
-  createPgMessagesSchema,
-  createPgWorkingMemorySchema,
-  createSqliteChatsSchema,
-  createSqliteMessagesSchema,
-  createSqliteWorkingMemorySchema,
-  SQL_SCHEMAS,
-} from "./providers/drizzle-schema.js";
-export { InMemoryProvider } from "./providers/in-memory.js";
-export { UpstashProvider } from "./providers/upstash.js";
-
+// Provider-agnostic root exports only.
+// Note: You can add provider-specific helpers in /providers (to avoid peer dependency conflicts)
 export type {
   ChatSession,
   ChatsConfig,

--- a/packages/memory/src/providers/drizzle-schema.ts
+++ b/packages/memory/src/providers/drizzle-schema.ts
@@ -16,7 +16,7 @@
  * @example
  * ```ts
  * import { pgTable } from 'drizzle-orm/pg-core';
- * import { createPgWorkingMemorySchema } from '@ai-sdk-tools/memory';
+ * import { createPgWorkingMemorySchema } from '@ai-sdk-tools/memory/drizzle';
  *
  * export const workingMemory = pgTable('working_memory', createPgWorkingMemorySchema());
  * ```
@@ -40,7 +40,7 @@ export function createPgWorkingMemorySchema() {
  * @example
  * ```ts
  * import { pgTable, serial } from 'drizzle-orm/pg-core';
- * import { createPgMessagesSchema } from '@ai-sdk-tools/memory';
+ * import { createPgMessagesSchema } from '@ai-sdk-tools/memory/drizzle';
  *
  * export const messages = pgTable('conversation_messages', createPgMessagesSchema());
  * ```
@@ -63,7 +63,7 @@ export function createPgMessagesSchema() {
  * @example
  * ```ts
  * import { mysqlTable } from 'drizzle-orm/mysql-core';
- * import { createMysqlWorkingMemorySchema } from '@ai-sdk-tools/memory';
+ * import { createMysqlWorkingMemorySchema } from '@ai-sdk-tools/memory/drizzle';
  *
  * export const workingMemory = mysqlTable('working_memory', createMysqlWorkingMemorySchema());
  * ```
@@ -100,7 +100,7 @@ export function createMysqlMessagesSchema() {
  * @example
  * ```ts
  * import { sqliteTable } from 'drizzle-orm/sqlite-core';
- * import { createSqliteWorkingMemorySchema } from '@ai-sdk-tools/memory';
+ * import { createSqliteWorkingMemorySchema } from '@ai-sdk-tools/memory/drizzle';
  *
  * export const workingMemory = sqliteTable('working_memory', createSqliteWorkingMemorySchema());
  * ```
@@ -140,7 +140,7 @@ export function createSqliteMessagesSchema() {
  * @example
  * ```ts
  * import { pgTable } from 'drizzle-orm/pg-core';
- * import { createPgChatsSchema } from '@ai-sdk-tools/memory';
+ * import { createPgChatsSchema } from '@ai-sdk-tools/memory/drizzle';
  *
  * export const chats = pgTable('chat_sessions', createPgChatsSchema());
  * ```
@@ -162,7 +162,7 @@ export function createPgChatsSchema() {
  * @example
  * ```ts
  * import { mysqlTable } from 'drizzle-orm/mysql-core';
- * import { createMysqlChatsSchema } from '@ai-sdk-tools/memory';
+ * import { createMysqlChatsSchema } from '@ai-sdk-tools/memory/drizzle';
  *
  * export const chats = mysqlTable('chat_sessions', createMysqlChatsSchema());
  * ```
@@ -184,7 +184,7 @@ export function createMysqlChatsSchema() {
  * @example
  * ```ts
  * import { sqliteTable } from 'drizzle-orm/sqlite-core';
- * import { createSqliteChatsSchema } from '@ai-sdk-tools/memory';
+ * import { createSqliteChatsSchema } from '@ai-sdk-tools/memory/drizzle';
  *
  * export const chats = sqliteTable('chat_sessions', createSqliteChatsSchema());
  * ```

--- a/packages/memory/src/providers/drizzle.ts
+++ b/packages/memory/src/providers/drizzle.ts
@@ -61,7 +61,7 @@ export interface ChatsTable {
 export interface DrizzleProviderConfig<
   TWM extends WorkingMemoryTable,
   TMsg extends ConversationMessagesTable,
-  TChat extends ChatsTable = ChatsTable,
+  TChat extends ChatsTable = ChatsTable
 > {
   /** Working memory table */
   workingMemoryTable: TWM;
@@ -89,13 +89,13 @@ export interface DrizzleProviderConfig<
 export class DrizzleProvider<
   TWM extends WorkingMemoryTable,
   TMsg extends ConversationMessagesTable,
-  TChat extends ChatsTable = ChatsTable,
+  TChat extends ChatsTable = ChatsTable
 > implements MemoryProvider
 {
   constructor(
     // Accepts any Drizzle database instance (postgres, mysql, sqlite adapters all have different types)
     private db: any,
-    private config: DrizzleProviderConfig<TWM, TMsg, TChat>,
+    private config: DrizzleProviderConfig<TWM, TMsg, TChat>
   ) {}
 
   async getWorkingMemory(params: {
@@ -298,3 +298,17 @@ export class DrizzleProvider<
     return `${scope}:${id}`;
   }
 }
+
+// Re-export schema helpers under drizzle subpath
+export {
+  createMysqlChatsSchema,
+  createMysqlMessagesSchema,
+  createMysqlWorkingMemorySchema,
+  createPgChatsSchema,
+  createPgMessagesSchema,
+  createPgWorkingMemorySchema,
+  createSqliteChatsSchema,
+  createSqliteMessagesSchema,
+  createSqliteWorkingMemorySchema,
+  SQL_SCHEMAS,
+} from "./drizzle-schema.js";

--- a/packages/memory/tsup.config.ts
+++ b/packages/memory/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/providers/*.ts"],
   format: ["cjs", "esm"],
   dts: true,
   splitting: false,


### PR DESCRIPTION
This PR refactors the `@ai-sdk-tools/memory` package to export providers separately via eg. `@ai-sdk-tools/memory/drizzle`.

Resolves #50 