### PR TITLE
Allow setting current artifact for useArtifact

### DIFF
--- a/packages/artifacts/src/hooks.ts
+++ b/packages/artifacts/src/hooks.ts
@@ -100,6 +100,7 @@ export function useArtifact<
     error: currentArtifact?.error,
     isActive,
     hasData: currentArtifact !== null,
+    setCurrentArtifact,
   };
 }
 

--- a/packages/artifacts/src/types.ts
+++ b/packages/artifacts/src/types.ts
@@ -55,6 +55,7 @@ export interface UseArtifactReturn<T = unknown> {
   error?: string;
   isActive: boolean;
   hasData: boolean;
+  setCurrentArtifact: (artifact: ArtifactData<T> | null) => void;
 }
 
 export interface UseArtifactsOptions {


### PR DESCRIPTION
## Summary

Expose setCurrentArtifact function from the useArtifact hook to allow programmatically loading existing artifact revisions from external sources.

## Motivation

Currently, the useArtifact hook only manages artifacts that are extracted from chat messages in the AI SDK stream. This works well for new artifacts being created during a conversation, but there's no way to initialize the hook with an existing artifact loaded from an external source (e.g., a database).

This limitation prevents use cases where:
- Users have a revision history stored in a database
- Users navigate to a specific artifact by ID and need to load the latest revision
- Applications want to hydrate artifacts from persistent storage before continuing conversations

For example, in a meal plan application:
1. User creates a meal plan artifact through AI chat
2. Revisions are saved to a database
3. User later navigates to /mealplan/:id
4. App needs to load the latest revision from the database
5. User continues chatting with AI to modify the meal plan, creating new revisions

Without setCurrentArtifact, there was no way to accomplish step 4.

## Changes

`packages/artifacts/src/types.ts`
- Added setCurrentArtifact: (artifact: ArtifactData<T> | null) => void to the UseArtifactReturn
 interface

`packages/artifacts/src/hooks.ts`
- Exported the existing setCurrentArtifact state setter from the hook's return object

## Usage Example

```tsx
const { data, setCurrentArtifact, status } = useArtifact(mealPlanArtifact);

// Load existing artifact from database when component mounts
useEffect(() => {
  const loadRevision = async () => {
    const revision = await fetchLatestRevision(revisionId);
    setCurrentArtifact(revision);
  };

  if (revisionId) {
    loadRevision();
  }
}, [revisionId]);
// The artifact is now displayed in the UI
// User can continue chatting with AI to create new revisions
// New revisions will automatically stream in via AI SDK
```