### PR TITLE
fix(devtools): add @ai-sdk-tools/store dependency for standalone usage

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -199,6 +199,7 @@
       "name": "@ai-sdk-tools/devtools",
       "version": "0.9.0",
       "dependencies": {
+        "@ai-sdk-tools/store": "workspace:*",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^7.3.4",
@@ -210,7 +211,6 @@
         "react-json-view-lite": "^2.5.0",
       },
       "devDependencies": {
-        "@ai-sdk-tools/store": "workspace:*",
         "@ai-sdk/react": "^2.0.78",
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.2",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -54,10 +54,10 @@
     "react-dom": "^19.2.0",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
-    "@ai-sdk/react": "^2.0.78",
-    "@ai-sdk-tools/store": "workspace:*"
+    "@ai-sdk/react": "^2.0.78"
   },
   "dependencies": {
+    "@ai-sdk-tools/store": "workspace:*",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^7.3.4",


### PR DESCRIPTION
Should fix this error:

```
> Build error occurred
Error: Turbopack build failed with 1 errors:
./node_modules/@ai-sdk-tools/devtools/dist/index.mjs:9:1
Module not found: Can't resolve '@ai-sdk-tools/store'
   7 | import { Build, Schedule, Error as Error$1, CheckCircle, PlayArrow, Help, Pause, Clear, ViewSidebar, ViewList, Close, DataObject, ErrorOutline, Api, Settings, Psychology, Circle, Code, Send } from '@mui/icons-material';
   8 | import { jsxs, Fragment, jsx } from 'react/jsx-runtime';
>  9 | import { ChatStoreContext as ChatStoreContext$1 } from '@ai-sdk-tools/store';
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  10 | import { JsonView, darkStyles } from 'react-json-view-lite';
  11 | import 'react-json-view-lite/dist/index.css';
  12 |



Import trace:
  Server Component:
    ./node_modules/@ai-sdk-tools/devtools/dist/index.mjs
    ./app/(chat)/layout.tsx

https://nextjs.org/docs/messages/module-not-found


    at ./node_modules/ (ai-sdk-tools/devtools/dist/index.mjs:9:1)
    at <unknown> (https://nextjs.org/docs/messages/module-not-found)
error: script "build" exited with code 1
```