### PR TITLE
fix(cache): use setWithTTL for Redis to properly set TTL

### DIFF
--- a/packages/cache/src/index.ts
+++ b/packages/cache/src/index.ts
@@ -9,7 +9,13 @@ export { cached, createCached, cacheTools } from "./cache";
 export type {
   CacheOptions,
   CachedTool,
+  CacheStore,
+  CacheEntry,
 } from "./types";
+
+export { createCacheBackend } from "./backends/factory";
+export type { CacheBackendConfig } from "./backends/factory";
+export { LRUCacheStore, SimpleCacheStore, RedisCacheStore, MemoryCacheStore } from "./backends/index";
 
 // Re-export useful types from ai package
 export type { Tool } from "ai";

--- a/packages/cache/src/types.ts
+++ b/packages/cache/src/types.ts
@@ -94,6 +94,9 @@ export interface CacheStore<T = any> {
   /** Set cache entry */
   set(key: string, entry: CacheEntry<T>): void | Promise<void>;
   
+  /** Set cache entry with TTL (time-to-live) in seconds */
+  setWithTTL?(key: string, entry: CacheEntry<T>, ttlSeconds: number): void | Promise<void>;
+  
   /** Delete cache entry */
   delete(key: string): boolean | Promise<boolean>;
   


### PR DESCRIPTION
Fixes #93

Problem:

The cache system wasn't actually using TTL for Redis. While `RedisCacheStore` has a `setWithTTL()` method that uses Redis SETEX, all cache writes were calling regular `set()` instead. This meant:
- Redis keys never expired
- Cache entries piled up in memory
- Had to rely on eviction policies instead of proper TTL management

Also, when using `createCached()`, you had to pass `ttl` twice - once to `createCached()` and again when calling the returned function. Pretty confusing.

Changes:

- Added optional `setWithTTL` to `CacheStore` interface
- Created helper function that uses `setWithTTL` when available, falls back to `set()` otherwise
- Updated all 4 cache write locations to use the helper
- Forward `ttl` from `createCached()` to `createCachedFunction()` so you only specify it once
- Exported missing types: `CacheBackendConfig`, `CacheStore`, `CacheEntry`, and `createCacheBackend` (these were referenced in README but not exported)