### PR TITLE
feat(cache): add per-tool cache key prefixing and improve API clarity

### DIFF
--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -175,6 +175,7 @@ For multi-tenant apps, isolate cache by user/team using `cacheKeyContext`:
 
 ```typescript
 import { cached } from '@ai-sdk-tools/cache';
+// Your app's context system (could be React context, global state, etc.)
 
 const burnRateAnalysisTool = tool({
   description: 'Analyze burn rate',
@@ -183,7 +184,9 @@ const burnRateAnalysisTool = tool({
     to: z.string(),
   }),
   execute: async ({ from, to }) => {
+    // Your app's way of getting current user/team context
     const currentUser = getCurrentUser();
+    
     return await db.getBurnRate({
       teamId: currentUser.teamId,
       from,
@@ -192,6 +195,7 @@ const burnRateAnalysisTool = tool({
   },
 });
 
+// Cache with context - that's it!
 export const cachedBurnRateTool = cached(burnRateAnalysisTool, {
   cacheKeyContext: () => {
     const currentUser = getCurrentUser();

--- a/packages/cache/src/backends/factory.ts
+++ b/packages/cache/src/backends/factory.ts
@@ -1,5 +1,5 @@
-import type { CacheStore } from "../types";
 import { LRUCacheStore, SimpleCacheStore } from "../cache-store";
+import type { CacheStore } from "../types";
 import { MemoryCacheStore } from "./memory";
 import { RedisCacheStore } from "./redis";
 
@@ -12,45 +12,50 @@ export interface CacheBackendConfig {
   defaultTTL?: number;
   redis?: {
     client: any;
-    keyPrefix?: string;
+    storeName?: string;
   };
 }
 
 /**
  * Factory function to create cache backends
  */
-export function createCacheBackend<T = any>(config: CacheBackendConfig): CacheStore<T> {
+export function createCacheBackend<T = any>(
+  config: CacheBackendConfig,
+): CacheStore<T> {
   let store: CacheStore<T>;
-  
+
   switch (config.type) {
     case "memory":
       store = new MemoryCacheStore<T>(config.maxSize);
       break;
-    
+
     case "lru":
       store = new LRUCacheStore<T>(config.maxSize);
       break;
-    
+
     case "simple":
       store = new SimpleCacheStore<T>(config.maxSize);
       break;
-    
+
     case "redis":
       if (!config.redis?.client) {
         throw new Error("Redis client is required for redis cache backend");
       }
-      store = new RedisCacheStore<T>(config.redis.client, config.redis.keyPrefix);
+      store = new RedisCacheStore<T>(
+        config.redis.client,
+        config.redis.storeName,
+      );
       break;
-    
+
     default:
       throw new Error(`Unknown cache backend type: ${(config as any).type}`);
   }
-  
+
   // Add default TTL support if configured
   if (config.defaultTTL) {
     (store as any).getDefaultTTL = () => config.defaultTTL;
   }
-  
+
   return store;
 }
 

--- a/packages/cache/src/backends/index.ts
+++ b/packages/cache/src/backends/index.ts
@@ -1,4 +1,4 @@
 export { LRUCacheStore, SimpleCacheStore } from "../cache-store";
-export { RedisCacheStore } from "./redis";
-export { MemoryCacheStore } from "./memory";
 export { createCacheBackend } from "./factory";
+export { MemoryCacheStore } from "./memory";
+export { RedisCacheStore } from "./redis";

--- a/packages/cache/src/backends/redis.ts
+++ b/packages/cache/src/backends/redis.ts
@@ -1,3 +1,7 @@
+import {
+	DEFAULT_CACHE_KEY_SEPARATOR,
+	DEFAULT_STORE_NAME,
+} from "../constants";
 import type { CacheEntry, CacheStore } from "../types";
 
 /**
@@ -8,9 +12,13 @@ export class RedisCacheStore<T = any> implements CacheStore<T> {
   private redis: any;
   private keyPrefix: string;
 
-  constructor(redisClient: any, keyPrefix = "ai-tools-cache:") {
+  constructor(redisClient: any, storeName = DEFAULT_STORE_NAME) {
     this.redis = redisClient;
-    this.keyPrefix = keyPrefix;
+    // Append separator if storeName doesn't end with a common separator
+    const endsWithSeparator = /[:|\-_]$/.test(storeName);
+    this.keyPrefix = storeName && !endsWithSeparator
+      ? `${storeName}${DEFAULT_CACHE_KEY_SEPARATOR}`
+      : storeName;
   }
 
   private getKey(key: string): string {
@@ -21,12 +29,12 @@ export class RedisCacheStore<T = any> implements CacheStore<T> {
     try {
       const data = await this.redis.get(this.getKey(key));
       if (!data) return undefined;
-      
+
       // Handle different Redis client return types
       let jsonString: string;
-      if (typeof data === 'string') {
+      if (typeof data === "string") {
         jsonString = data;
-      } else if (typeof data === 'object') {
+      } else if (typeof data === "object") {
         // Some Redis clients return objects directly
         return {
           result: data.result,
@@ -37,7 +45,7 @@ export class RedisCacheStore<T = any> implements CacheStore<T> {
         // Convert other types to string
         jsonString = String(data);
       }
-      
+
       const parsed = JSON.parse(jsonString);
       return {
         result: parsed.result,
@@ -57,21 +65,25 @@ export class RedisCacheStore<T = any> implements CacheStore<T> {
         timestamp: entry.timestamp,
         key: entry.key,
       });
-      
+
       await this.redis.set(this.getKey(key), data);
     } catch (error) {
       console.warn(`Redis cache set error for key ${key}:`, error);
     }
   }
 
-  async setWithTTL(key: string, entry: CacheEntry<T>, ttlSeconds: number): Promise<void> {
+  async setWithTTL(
+    key: string,
+    entry: CacheEntry<T>,
+    ttlSeconds: number,
+  ): Promise<void> {
     try {
       const data = JSON.stringify({
         result: entry.result,
         timestamp: entry.timestamp,
         key: entry.key,
       });
-      
+
       await this.redis.setex(this.getKey(key), ttlSeconds, data);
     } catch (error) {
       console.warn(`Redis cache setex error for key ${key}:`, error);

--- a/packages/cache/src/backends/redis.ts
+++ b/packages/cache/src/backends/redis.ts
@@ -1,7 +1,4 @@
-import {
-	DEFAULT_CACHE_KEY_SEPARATOR,
-	DEFAULT_STORE_NAME,
-} from "../constants";
+import { DEFAULT_CACHE_KEY_SEPARATOR, DEFAULT_STORE_NAME } from "../constants";
 import type { CacheEntry, CacheStore } from "../types";
 
 /**
@@ -16,9 +13,10 @@ export class RedisCacheStore<T = any> implements CacheStore<T> {
     this.redis = redisClient;
     // Append separator if storeName doesn't end with a common separator
     const endsWithSeparator = /[:|\-_]$/.test(storeName);
-    this.keyPrefix = storeName && !endsWithSeparator
-      ? `${storeName}${DEFAULT_CACHE_KEY_SEPARATOR}`
-      : storeName;
+    this.keyPrefix =
+      storeName && !endsWithSeparator
+        ? `${storeName}${DEFAULT_CACHE_KEY_SEPARATOR}`
+        : storeName;
   }
 
   private getKey(key: string): string {

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -641,17 +641,16 @@ export function createCachedFunction(
 /**
  * Cache multiple tools with the same configuration
  */
-export function cacheTools<
-  T extends Tool,
-  TTools extends Record<PropertyKey, T>,
->(tools: TTools, options: CacheOptions = {}) {
-  const entries = Object.entries(tools);
-  const cachedEntries = entries.map(
-    ([name, tool]) => [name, cached(tool, options)] as const,
-  ) as { [K in keyof TTools]: [K, CachedTool<TTools[K]>] }[keyof TTools][];
+export function cacheTools<T extends Tool, TTools extends Record<string, T>>(
+  tools: TTools,
+  options: CacheOptions = {},
+): { [K in keyof TTools]: CachedTool<TTools[K]> } {
+  const entries = Object.entries(tools).map(
+    ([name, tool]) => [name as keyof TTools, cached(tool, options)] as const,
+  );
 
-  return Object.fromEntries(cachedEntries) as {
-    [K in (typeof cachedEntries)[number] as K[0]]: K[1];
+  return Object.fromEntries(entries) as {
+    [K in keyof TTools]: CachedTool<TTools[K]>;
   };
 }
 

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -1,7 +1,7 @@
 import type { Tool } from "ai";
 import { createCacheBackend } from "./backends";
 import { LRUCacheStore } from "./cache-store";
-import {DEFAULT_CACHE_KEY_SEPARATOR, DEFAULT_STORE_NAME} from "./constants";
+import { DEFAULT_CACHE_KEY_SEPARATOR, DEFAULT_STORE_NAME } from "./constants";
 import type { CachedTool, CacheOptions, CacheStats, CacheStore } from "./types";
 
 /**
@@ -641,16 +641,18 @@ export function createCachedFunction(
 /**
  * Cache multiple tools with the same configuration
  */
-export function cacheTools<T extends Tool, TTools extends Record<string, T>>(
-  tools: TTools,
-  options: CacheOptions = {},
-): { [K in keyof TTools]: CachedTool<TTools[K]> } {
-  const entries =  Object.entries(tools).map(([name, tool]) => [
-    name as keyof TTools,
-    cached(tool, options),
-  ] as const)
+export function cacheTools<
+  T extends Tool,
+  TTools extends Record<PropertyKey, T>,
+>(tools: TTools, options: CacheOptions = {}) {
+  const entries = Object.entries(tools);
+  const cachedEntries = entries.map(
+    ([name, tool]) => [name, cached(tool, options)] as const,
+  ) as { [K in keyof TTools]: [K, CachedTool<TTools[K]>] }[keyof TTools][];
 
-  return Object.fromEntries(entries) as { [K in keyof TTools]: CachedTool<TTools[K]> }
+  return Object.fromEntries(cachedEntries) as {
+    [K in (typeof cachedEntries)[number] as K[0]]: K[1];
+  };
 }
 
 /**

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -645,7 +645,12 @@ export function cacheTools<T extends Tool, TTools extends Record<string, T>>(
   tools: TTools,
   options: CacheOptions = {},
 ): { [K in keyof TTools]: CachedTool<TTools[K]> } {
-  return Object.fromEntries(Object.keys(tools).map((name) => ([[name as keyof TTools], cached(tools[name], options)])))
+  const entries =  Object.entries(tools).map(([name, tool]) => [
+    name as keyof TTools,
+    cached(tool, options),
+  ] as const)
+
+  return Object.fromEntries(entries) as { [K in keyof TTools]: CachedTool<TTools[K]> }
 }
 
 /**

--- a/packages/cache/src/constants.ts
+++ b/packages/cache/src/constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Default separator used between cache key parts.
+ * Colon is ideal for Redis hierarchy visualization.
+ */
+export const DEFAULT_CACHE_KEY_SEPARATOR = ":";
+export const DEFAULT_STORE_NAME = "ai-tools-cache";

--- a/packages/cache/src/examples/basic-usage.ts
+++ b/packages/cache/src/examples/basic-usage.ts
@@ -94,7 +94,7 @@ const calculatorTool = tool({
       // Simple expression evaluation (use a proper math parser in production)
       const result = Function(`"use strict"; return (${expression})`)();
       return { expression, result, success: true };
-    } catch (error) {
+    } catch (_error) {
       return { expression, error: "Invalid expression", success: false };
     }
   },

--- a/packages/cache/src/examples/basic-usage.ts
+++ b/packages/cache/src/examples/basic-usage.ts
@@ -199,7 +199,7 @@ export async function demonstrateCache() {
 export async function demonstrateCacheManagement() {
   console.log("🔧 Cache Management Demo\n");
 
-  const tool = cached(weatherTool, { debug: true });
+  const tool = cached(expensiveWeatherTool, { debug: true });
 
   // Add some entries
   await tool.execute?.({ location: "Paris", units: 'celsius' }, {toolCallId: 'weatherTool', messages: []});

--- a/packages/cache/src/examples/basic-usage.ts
+++ b/packages/cache/src/examples/basic-usage.ts
@@ -146,15 +146,24 @@ export async function demonstrateCache() {
   console.log("=== Weather Tool Demo ===");
 
   console.log("First call (should be slow):");
-  const weather1 = await weatherTool.execute?.({ location: "New York", units: 'fahrenheit' }, {toolCallId: 'weatherTool', messages: []});
+  const weather1 = await weatherTool.execute?.(
+    { location: "New York", units: "fahrenheit" },
+    { toolCallId: "weatherTool", messages: [] },
+  );
   console.log("Result:", weather1);
 
   console.log("\nSecond call with same params (should be fast):");
-  const weather2 = await weatherTool.execute?.({ location: "New York", units: 'fahrenheit' }, {toolCallId: 'weatherTool', messages: []});
+  const weather2 = await weatherTool.execute?.(
+    { location: "New York", units: "fahrenheit" },
+    { toolCallId: "weatherTool", messages: [] },
+  );
   console.log("Result:", weather2);
 
   console.log("\nThird call with different params (should be slow):");
-  const weather3 = await weatherTool.execute?.({ location: "London", units: 'celsius' },  {toolCallId: 'weatherTool', messages: []});
+  const weather3 = await weatherTool.execute?.(
+    { location: "London", units: "celsius" },
+    { toolCallId: "weatherTool", messages: [] },
+  );
   console.log("Result:", weather3);
 
   // Show cache stats
@@ -163,17 +172,23 @@ export async function demonstrateCache() {
   // Test burn rate tool
   console.log("\n=== Burn Rate Analysis Demo ===");
 
-  const analysis1 = await cachedBurnRateTool.execute?.({
-    companyId: "company-123",
-    months: 12,
-  },  {toolCallId: 'cachedBurnRateTool', messages: []});
+  const analysis1 = await cachedBurnRateTool.execute?.(
+    {
+      companyId: "company-123",
+      months: 12,
+    },
+    { toolCallId: "cachedBurnRateTool", messages: [] },
+  );
   console.log("Analysis result:", analysis1);
 
   // Same params - should hit cache
-  const analysis2 = await cachedBurnRateTool.execute?.({
-    companyId: "company-123",
-    months: 12,
-  }, {toolCallId: 'cachedBurnRateTool', messages: []});
+  const analysis2 = await cachedBurnRateTool.execute?.(
+    {
+      companyId: "company-123",
+      months: 12,
+    },
+    { toolCallId: "cachedBurnRateTool", messages: [] },
+  );
   console.log("Cached analysis:", analysis2);
 
   console.log("\nBurn rate tool cache stats:", cachedBurnRateTool.getStats());
@@ -181,11 +196,23 @@ export async function demonstrateCache() {
   // Test multiple tools
   console.log("\n=== Multiple Tools Demo ===");
 
-  await calculator.execute?.({ expression: "15 * 8" }, {toolCallId: 'calculator', messages: []});
-  await calculator.execute?.({ expression: "15 * 8" }, {toolCallId: 'calculator', messages: []}); // Should hit cache
+  await calculator.execute?.(
+    { expression: "15 * 8" },
+    { toolCallId: "calculator", messages: [] },
+  );
+  await calculator.execute?.(
+    { expression: "15 * 8" },
+    { toolCallId: "calculator", messages: [] },
+  ); // Should hit cache
 
-  await database.execute?.({ query: "SELECT * FROM users", table: "users" }, {toolCallId: 'database', messages: []});
-  await database.execute?.({ query: "SELECT * FROM users", table: "users" }, {toolCallId: 'database', messages: []}); // Should hit cache
+  await database.execute?.(
+    { query: "SELECT * FROM users", table: "users" },
+    { toolCallId: "database", messages: [] },
+  );
+  await database.execute?.(
+    { query: "SELECT * FROM users", table: "users" },
+    { toolCallId: "database", messages: [] },
+  ); // Should hit cache
 
   console.log("\nCalculator cache stats:", calculator.getStats());
   console.log("Database cache stats:", database.getStats());
@@ -202,9 +229,18 @@ export async function demonstrateCacheManagement() {
   const tool = cached(expensiveWeatherTool, { debug: true });
 
   // Add some entries
-  await tool.execute?.({ location: "Paris", units: 'celsius' }, {toolCallId: 'weatherTool', messages: []});
-  await tool.execute?.({ location: "Tokyo", units: 'celsius' }, {toolCallId: 'weatherTool', messages: []});
-  await tool.execute?.({ location: "Sydney", units: 'celsius' }, {toolCallId: 'weatherTool', messages: []});
+  await tool.execute?.(
+    { location: "Paris", units: "celsius" },
+    { toolCallId: "weatherTool", messages: [] },
+  );
+  await tool.execute?.(
+    { location: "Tokyo", units: "celsius" },
+    { toolCallId: "weatherTool", messages: [] },
+  );
+  await tool.execute?.(
+    { location: "Sydney", units: "celsius" },
+    { toolCallId: "weatherTool", messages: [] },
+  );
 
   console.log("Cache stats after adding entries:", tool.getStats());
 

--- a/packages/cache/src/examples/user-config.ts
+++ b/packages/cache/src/examples/user-config.ts
@@ -16,7 +16,7 @@ const redisClient = Redis.createClient({
   socket: {
     host: "localhost",
     port: 6379,
-  }
+  },
 });
 
 const redisBackend = createCacheBackend({

--- a/packages/cache/src/examples/user-config.ts
+++ b/packages/cache/src/examples/user-config.ts
@@ -3,32 +3,34 @@
  * This is the recommended pattern for configuring cache backends
  */
 
-import { cached as baseCached } from '../index';
-import { createCacheBackend } from '../backends/factory';
-import type { CacheOptions } from '../index';
-import type { Tool } from 'ai';
-import Redis from 'redis'; // User installs this
+import type { Tool } from "ai";
+import Redis from "redis"; // User installs this
+import { createCacheBackend } from "../backends";
+import type { CacheOptions } from "../index";
+import { cached as baseCached } from "../index";
 
 // ===== User's cache configuration file (e.g., src/lib/cache.ts) =====
 
 // 1. Create your cache backend
 const redisClient = Redis.createClient({
-  host: 'localhost',
-  port: 6379,
+  socket: {
+    host: "localhost",
+    port: 6379,
+  }
 });
 
 const redisBackend = createCacheBackend({
-  type: 'redis',
+  type: "redis",
   redis: {
     client: redisClient,
-    keyPrefix: 'my-app:',
+    storeName: "my-app",
   },
 });
 
 // 2. Export your configured cache function
 export function cached<T extends Tool>(
-  tool: T, 
-  options: Omit<CacheOptions, 'store'> = {}
+  tool: T,
+  options: Omit<CacheOptions, "store"> = {},
 ) {
   return baseCached(tool, {
     ...options,
@@ -39,25 +41,25 @@ export function cached<T extends Tool>(
 // ===== Alternative: Multiple preset functions =====
 
 export const redisCached = <T extends Tool>(
-  tool: T, 
-  options: Omit<CacheOptions, 'store'> = {}
+  tool: T,
+  options: Omit<CacheOptions, "store"> = {},
 ) => {
   return baseCached(tool, { ...options, store: redisBackend });
 };
 
 export const lruCached = <T extends Tool>(
-  tool: T, 
-  options: Omit<CacheOptions, 'store'> = {}
+  tool: T,
+  options: Omit<CacheOptions, "store"> = {},
 ) => {
-  const lruBackend = createCacheBackend({ type: 'lru', maxSize: 1000 });
+  const lruBackend = createCacheBackend({ type: "lru", maxSize: 1000 });
   return baseCached(tool, { ...options, store: lruBackend });
 };
 
 export const memoryCached = <T extends Tool>(
-  tool: T, 
-  options: Omit<CacheOptions, 'store'> = {}
+  tool: T,
+  options: Omit<CacheOptions, "store"> = {},
 ) => {
-  const memoryBackend = createCacheBackend({ type: 'memory', maxSize: 2000 });
+  const memoryBackend = createCacheBackend({ type: "memory", maxSize: 2000 });
   return baseCached(tool, { ...options, store: memoryBackend });
 };
 
@@ -70,7 +72,7 @@ export const memoryCached = <T extends Tool>(
 // In your tools files:
 // import { cached } from '@ai-sdk-tools/cache';
 // import { getContext } from '@/ai/context';
-// 
+//
 // // Global tools (no context needed)
 // const weatherTool = cached(expensiveWeatherTool, {
 //   ttl: 10 * 60 * 1000, // 10 minutes
@@ -91,14 +93,14 @@ function createAppCacheBackend() {
   if (process.env.REDIS_URL) {
     const redis = Redis.createClient({ url: process.env.REDIS_URL });
     return createCacheBackend({
-      type: 'redis',
-      redis: { client: redis, keyPrefix: 'app:' },
+      type: "redis",
+      redis: { client: redis, storeName: "app" },
     });
   }
-  
+
   // Fallback to memory cache in development
   return createCacheBackend({
-    type: 'memory',
+    type: "memory",
     maxSize: 1000,
   });
 }
@@ -106,8 +108,8 @@ function createAppCacheBackend() {
 const appCacheBackend = createAppCacheBackend();
 
 export const appCached = <T extends Tool>(
-  tool: T, 
-  options: Omit<CacheOptions, 'store'> = {}
+  tool: T,
+  options: Omit<CacheOptions, "store"> = {},
 ) => {
   return baseCached(tool, { ...options, store: appCacheBackend });
 };

--- a/packages/cache/src/index.ts
+++ b/packages/cache/src/index.ts
@@ -1,15 +1,12 @@
 /**
  * @ai-sdk-tools/cache
- * 
- * Simple caching wrapper for AI SDK tools. Cache expensive tool executions 
+ *
+ * Simple caching wrapper for AI SDK tools. Cache expensive tool executions
  * with zero configuration.
  */
 
-export { cached, createCached, cacheTools } from "./cache";
+export { cached, cacheTools, createCached, serializeValue } from "./cache";
 export type {
-  CacheOptions,
   CachedTool,
+  CacheOptions,
 } from "./types";
-
-// Re-export useful types from ai package
-export type { Tool } from "ai";

--- a/packages/cache/src/types.ts
+++ b/packages/cache/src/types.ts
@@ -6,28 +6,57 @@ import type { Tool } from "ai";
 export interface CacheOptions {
   /** Cache duration in milliseconds (default: 5 minutes) */
   ttl?: number;
-  
+
   /** Maximum cache size (default: 1000 entries) */
   maxSize?: number;
-  
+
   /** Custom cache store backend */
   store?: CacheStore;
-  
+
+  /**
+   * Optional tool name to prefix cache keys with.
+   * Prevents collisions between tools using similar parameters.
+   */
+  toolName?: string;
+
+  /**
+   * Separator used between cache key components.
+   *
+   * @default ':'
+   */
+  keySeparator?: string;
+
   /** Custom cache key generator */
-  keyGenerator?: (params: any, context?: any) => string;
-  
-  /** Function to generate cache key context */
+  keyGenerator?: (options: {
+    params: any;
+    context?: any;
+    toolName?: string;
+    keySeparator?: string;
+  }) => string;
+
+  /**
+   * Function to generate dynamic cache key context suffix.
+   * Appended to the end of the cache key with separator in between.
+   * Use for multi-tenant apps to isolate cache by user/team.
+   */
+  cacheKeyContext?: () => string;
+
+  /**
+   * @deprecated Use `cacheKeyContext` instead.
+   *
+   * Function to generate cache key context suffix.
+   */
   cacheKey?: () => string;
-  
+
   /** Whether to cache this result */
   shouldCache?: (params: any, result: any) => boolean;
-  
+
   /** Cache hit callback */
   onHit?: (key: string) => void;
-  
+
   /** Cache miss callback */
   onMiss?: (key: string) => void;
-  
+
   /** Enable debug logging */
   debug?: boolean;
 }
@@ -38,10 +67,10 @@ export interface CacheOptions {
 export interface CacheEntry<T = any> {
   /** Cached result */
   result: T;
-  
+
   /** Timestamp when cached */
   timestamp: number;
-  
+
   /** Cache key */
   key: string;
 }
@@ -52,16 +81,16 @@ export interface CacheEntry<T = any> {
 export interface CacheStats {
   /** Number of cache hits */
   hits: number;
-  
+
   /** Number of cache misses */
   misses: number;
-  
+
   /** Hit rate (0-1) */
   hitRate: number;
-  
+
   /** Current cache size */
   size: number;
-  
+
   /** Maximum cache size */
   maxSize: number;
 }
@@ -72,13 +101,13 @@ export interface CacheStats {
 export type CachedTool<T extends Tool = Tool> = T & {
   /** Get cache statistics */
   getStats(): CacheStats;
-  
+
   /** Clear cache entries */
   clearCache(key?: string): void;
-  
+
   /** Check if parameters are cached */
   isCached(params: any): boolean | Promise<boolean>;
-  
+
   /** Get cache key for parameters */
   getCacheKey(params: any): string;
 };
@@ -89,26 +118,28 @@ export type CachedTool<T extends Tool = Tool> = T & {
  */
 export interface CacheStore<T = any> {
   /** Get cached entry */
-  get(key: string): CacheEntry<T> | undefined | Promise<CacheEntry<T> | undefined>;
-  
+  get(
+    key: string,
+  ): CacheEntry<T> | undefined | Promise<CacheEntry<T> | undefined>;
+
   /** Set cache entry */
   set(key: string, entry: CacheEntry<T>): void | Promise<void>;
-  
+
   /** Delete cache entry */
   delete(key: string): boolean | Promise<boolean>;
-  
+
   /** Clear all entries */
   clear(): void | Promise<void>;
-  
+
   /** Check if key exists */
   has(key: string): boolean | Promise<boolean>;
-  
+
   /** Get current size */
   size(): number | Promise<number>;
-  
+
   /** Get all keys */
   keys(): string[] | Promise<string[]>;
-  
+
   /** Get default TTL if configured */
   getDefaultTTL?(): number | undefined;
 }

--- a/packages/cache/tsconfig.json
+++ b/packages/cache/tsconfig.json
@@ -18,13 +18,6 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true
   },
-  "include": [
-    "src/**/*"
-  ],
-  "exclude": [
-    "dist",
-    "node_modules",
-    "**/*.test.ts",
-    "**/*.spec.ts"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "**/*.test.ts", "**/*.spec.ts"]
 }


### PR DESCRIPTION
## Summary

This PR adds per-tool cache key prefixing to prevent cache collisions between different tools using the same parameters, and improves Redis key organization with clearer hierarchy.

Fixes #91

## Problem

Cache keys could clash between different tools when using the same parameters. For example, a weather tool and news tool both receiving `{ location: "NYC" }` would generate the same cache key, causing incorrect cached results.

## Key Changes

**New Features:**
- **Per-tool prefixing**: Add `toolName` option to namespace cache keys per tool
- **Configurable separator**: Add `keySeparator` option (default `":"`)
- **Clearer naming**: `cacheKeyContext` replaces `cacheKey` (better reflects it's a suffix)

**Breaking Changes:**
- `keyPrefix` → `storeName` in RedisCacheStore and CacheBackendConfig
- Default changed from `"ai-tools-cache:"` to `"ai-tools-cache"` (separator added automatically)
- `keyGenerator` signature changed from positional to object parameters

**Deprecations:**
- `cacheKey` deprecated in favor of `cacheKeyContext` (backward compatible)

## Migration Examples

### keyGenerator
```typescript
// Before
const keyGenerator = (params: any, context?: any): string => {
  return `custom-${JSON.stringify(params)}`;
};

// After
const keyGenerator = ({ params, context, toolName, keySeparator }: {
  params: any;
  context?: any;
  toolName?: string;
  keySeparator?: string;
}): string => {
  return `custom-${JSON.stringify(params)}`;
};
```

## Usage Example

```typescript
const weatherTool = createCached(tool({ /* ... */ }), {
  toolName: "weather",
  ttl: 3600
});

const newsTool = createCached(tool({ /* ... */ }), {
  toolName: "news",
  ttl: 1800
});
```

Keys structure: `storeName:toolName:params:context`

**Note:**  there are breaking changes, not sure if contributors are suppose to run changeset?