### PR TITLE
Guard store browser APIs for React Native compatibility

### DIFF
--- a/packages/store/src/hooks.ts
+++ b/packages/store/src/hooks.ts
@@ -83,13 +83,28 @@ function startFreezeDetector({
       );
     }
     __freezeLastTs = now;
-    __freezeRafId = window.requestAnimationFrame(tick);
+    if (
+      typeof window !== "undefined" &&
+      typeof window.requestAnimationFrame === "function"
+    ) {
+      __freezeRafId = window.requestAnimationFrame(tick);
+    }
   };
 
-  __freezeRafId = window.requestAnimationFrame(tick);
-  window.addEventListener("beforeunload", () => {
-    if (__freezeRafId) cancelAnimationFrame(__freezeRafId);
-  });
+  if (
+    typeof window !== "undefined" &&
+    typeof window.requestAnimationFrame === "function"
+  ) {
+    __freezeRafId = window.requestAnimationFrame(tick);
+  }
+
+  if (typeof window !== "undefined" && typeof window.addEventListener === "function") {
+    window.addEventListener("beforeunload", () => {
+      if (__freezeRafId && typeof cancelAnimationFrame === "function") {
+        cancelAnimationFrame(__freezeRafId);
+      }
+    });
+  }
 }
 
 if (typeof window !== "undefined") {

--- a/packages/store/src/use-chat.ts
+++ b/packages/store/src/use-chat.ts
@@ -132,11 +132,14 @@ export function useChat<TMessage extends UIMessage = UIMessage>(
 
     if (enableBatching) {
       // Use requestAnimationFrame for batching if available
-      if (window?.requestAnimationFrame) {
-        window.requestAnimationFrame(() => syncState(chatState));
-      } else {
-        syncState(chatState);
-      }
+    if (
+      typeof window !== "undefined" &&
+      typeof window.requestAnimationFrame === "function"
+    ) {
+      window.requestAnimationFrame(() => syncState(chatState));
+    } else {
+      syncState(chatState);
+    }
     } else {
       syncState(chatState);
     }


### PR DESCRIPTION
Fixes #39

Problem:

`@ai-sdk-tools/store` initializes utilities that assume a browser environment. React Native ships without `window`, so the freeze detector’s `requestAnimationFrame` loop and the batched sync `beforeunload` listener crash immediately once the store imports.

Changes:

- Guard the freeze detector’s `requestAnimationFrame` loop and `beforeunload` listener in `hooks.ts`, only registering them when `window` and the APIs exist.
- Safely call `cancelAnimationFrame` by checking for its availability.
- Wrap the batching path in `use-chat.ts` so React Native falls back to direct `syncState` when `requestAnimationFrame` isn’t present.
