### PR TITLE
fix(agent): Add method to strip provider metadata from history messages to prevent duplicate ID errors

### DIFF
--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -51,7 +51,7 @@ import type {
   OutputGuardrail,
   ToolPermissions,
 } from "./types.js";
-import { extractTextFromMessage } from "./utils.js";
+import { extractTextFromMessage, stripMetadata } from "./utils.js";
 
 const logger = createLogger("AGENT");
 
@@ -1522,8 +1522,9 @@ Good suggestions are:
         return convertToModelMessages([message]);
       }
 
-      // Convert stored messages
-      const historyMessages = convertToModelMessages(previousMessages);
+      const historyMessages = convertToModelMessages(
+        stripMetadata(previousMessages),
+      );
 
       logger.debug(
         `Loaded ${historyMessages.length} history messages for context`,

--- a/packages/agents/src/utils.ts
+++ b/packages/agents/src/utils.ts
@@ -1,4 +1,4 @@
-import type { ModelMessage } from "ai";
+import { isToolUIPart, type ModelMessage, type UIMessage } from "ai";
 
 /**
  * Extract text content from a ModelMessage.
@@ -35,4 +35,30 @@ export function extractTextFromMessage(
   }
 
   return "";
+}
+
+/**
+ * Strip metadata from UI messages to prevent duplicate ID errors.
+ * Provider metadata (like OpenAI item IDs) should not be reused across API calls.
+ */
+export function stripMetadata(messages: UIMessage[]): UIMessage[] {
+  return messages.map((msg) => ({
+    ...msg,
+    parts: msg.parts?.map((part) => {
+      const sanitizedPart: typeof part = { ...part };
+
+      if ("providerMetadata" in sanitizedPart) {
+        sanitizedPart.providerMetadata = undefined;
+      }
+
+      if (
+        isToolUIPart(sanitizedPart) &&
+        "callProviderMetadata" in sanitizedPart
+      ) {
+        sanitizedPart.callProviderMetadata = undefined;
+      }
+
+      return sanitizedPart;
+    }),
+  }));
 }


### PR DESCRIPTION
Fixes [#98](https://github.com/midday-ai/ai-sdk-tools/issues/98)

Problem:

When loading conversation history, provider metadata (like OpenAI item IDs) from previous messages was being reused in new API calls. This caused duplicate ID errors because provider-specific metadata shouldn't be reused across different API requests. The metadata is meant to be ephemeral and tied to a specific API response, not persisted and reused.

Changes:

- Added `stripMetadata()` utility function to sanitize UI messages by removing provider-specific metadata
- Strips `providerMetadata` from all message parts
- Strips `callProviderMetadata` from tool UI parts (using `isToolUIPart` type guard)
- Updated `loadMessagesWithHistory()` to sanitize previous messages before converting them to model messages
- Added necessary imports: `isToolUIPart`, `UIMessage` from "ai" package