### PR TITLE
refactor(devtools): make use of root level css variable.

### DIFF
--- a/packages/devtools/src/components/ai-dev-tools.tsx
+++ b/packages/devtools/src/components/ai-dev-tools.tsx
@@ -140,12 +140,7 @@ export function AIDevtools({
           isCapturing={isCapturing}
           onToggleCapturing={toggleCapturing}
           onClearEvents={clearEvents}
-          onClose={() => {
-            document.documentElement.style.removeProperty('--ai-devtools-panel-width');
-            document.documentElement.style.removeProperty('--ai-devtools-panel-height');
-            
-            setIsOpen(false)
-          }}
+          onClose={() => setIsOpen(false)}
           onTogglePosition={togglePosition}
           config={finalConfig}
         />

--- a/packages/devtools/src/components/ai-dev-tools.tsx
+++ b/packages/devtools/src/components/ai-dev-tools.tsx
@@ -140,7 +140,12 @@ export function AIDevtools({
           isCapturing={isCapturing}
           onToggleCapturing={toggleCapturing}
           onClearEvents={clearEvents}
-          onClose={() => setIsOpen(false)}
+          onClose={() => {
+            document.documentElement.style.removeProperty('--ai-devtools-panel-width');
+            document.documentElement.style.removeProperty('--ai-devtools-panel-height');
+            
+            setIsOpen(false)
+          }}
           onTogglePosition={togglePosition}
           config={finalConfig}
         />

--- a/packages/devtools/src/components/devtools-panel.tsx
+++ b/packages/devtools/src/components/devtools-panel.tsx
@@ -121,8 +121,6 @@ export function DevtoolsPanel({
 
   // Resize functionality
   const [isResizing, setIsResizing] = useState(false);
-  const [panelHeight, setPanelHeight] = useState(config.height || 300);
-  const [panelWidth, setPanelWidth] = useState(config.width || 500);
   const panelRef = useRef<HTMLDivElement>(null);
   const resizeRef = useRef<HTMLButtonElement>(null);
 
@@ -229,12 +227,18 @@ export function DevtoolsPanel({
         const newHeight = window.innerHeight - e.clientY;
         const minHeight = 200;
         const maxHeight = window.innerHeight * 0.8;
-        setPanelHeight(Math.max(minHeight, Math.min(maxHeight, newHeight)));
+        const newPanelHeight = Math.max(minHeight, Math.min(maxHeight, newHeight));
+        
+        document.documentElement.style.removeProperty('--ai-devtools-panel-width');
+        document.documentElement.style.setProperty('--ai-devtools-panel-height', `${newPanelHeight}px`);
       } else {
         const newWidth = window.innerWidth - e.clientX;
         const minWidth = 500;
         const maxWidth = window.innerWidth * 0.8;
-        setPanelWidth(Math.max(minWidth, Math.min(maxWidth, newWidth)));
+        const newPanelWidth = Math.max(minWidth, Math.min(maxWidth, newWidth));
+
+        document.documentElement.style.removeProperty('--ai-devtools-panel-height');
+        document.documentElement.style.setProperty('--ai-devtools-panel-width', `${newPanelWidth}px`);
       }
     },
     [isResizing, config.position],
@@ -350,8 +354,8 @@ export function DevtoolsPanel({
       ref={panelRef}
       className={`ai-devtools-panel ai-devtools-panel-${config.position} ${className}`}
       style={{
-        height: config.position === "bottom" ? panelHeight : undefined,
-        width: config.position === "right" ? panelWidth : undefined,
+        height: config.position === "bottom" ? 'var(--ai-devtools-panel-height)' : undefined,
+        width: config.position === "right" ? 'var(--ai-devtools-panel-width)' : undefined,
       }}
     >
       {/* Resize Handle */}

--- a/packages/devtools/src/components/devtools-panel.tsx
+++ b/packages/devtools/src/components/devtools-panel.tsx
@@ -123,6 +123,8 @@ export function DevtoolsPanel({
   const [isResizing, setIsResizing] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
   const resizeRef = useRef<HTMLButtonElement>(null);
+  const minHeight = 400;
+  const minWidth = 500;
 
   // Animation state for REC indicator
   const [isReceivingEvents, setIsReceivingEvents] = useState(false);
@@ -225,7 +227,6 @@ export function DevtoolsPanel({
 
       if (config.position === "bottom") {
         const newHeight = window.innerHeight - e.clientY;
-        const minHeight = 200;
         const maxHeight = window.innerHeight * 0.8;
         const newPanelHeight = Math.max(minHeight, Math.min(maxHeight, newHeight));
         
@@ -233,7 +234,6 @@ export function DevtoolsPanel({
         document.documentElement.style.setProperty('--ai-devtools-panel-height', `${newPanelHeight}px`);
       } else {
         const newWidth = window.innerWidth - e.clientX;
-        const minWidth = 500;
         const maxWidth = window.innerWidth * 0.8;
         const newPanelWidth = Math.max(minWidth, Math.min(maxWidth, newWidth));
 
@@ -354,8 +354,8 @@ export function DevtoolsPanel({
       ref={panelRef}
       className={`ai-devtools-panel ai-devtools-panel-${config.position} ${className}`}
       style={{
-        height: config.position === "bottom" ? 'var(--ai-devtools-panel-height)' : undefined,
-        width: config.position === "right" ? 'var(--ai-devtools-panel-width)' : undefined,
+        height: config.position === "bottom" ? `var(--ai-devtools-panel-height, ${minHeight}px)` : undefined,
+        width: config.position === "right" ? `var(--ai-devtools-panel-width, ${minWidth}px)` : undefined,
       }}
     >
       {/* Resize Handle */}


### PR DESCRIPTION
I replaced state-driven panel resizing with CSS custom properties set on the root HTML element. This decouples sizing from React state, lets CSS handle layout changes when the devtools panel moves or resizes, and provides a smoother developer experience when iterating on our own UIs.

## Usage

If I'm building an interface with shadcn sidebar for example, then I can add the following classNames to the `SidebarInset`

```tsx
className={cn(
    // ... inset classes
    process.env.NODE_ENV === 'development' &&
        '[&:has(.ai-devtools-panel-bottom)]:h-[calc(100dvh-var(--ai-devtools-panel-height))]',
    process.env.NODE_ENV === 'development' &&
        '[&:has(.ai-devtools-panel-right)]:mr-(--ai-devtools-panel-width)'
)}
```

Now my interface will automatically adjust based on the variable value. Solid DX win.